### PR TITLE
Depend on openmediatransport-rs and vmx-rs via GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           toolchain: "1.97"
           components: rustfmt
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
       - run: cargo fmt --all -- --check
 
   clippy-test:
@@ -53,11 +48,6 @@ jobs:
             libxcb-render0-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
       - name: Clippy (workspace libs/tools)
         run: cargo clippy -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike -p omt-studio-monitor -p omt-test-patterns --all-targets -- -D warnings
       - name: Test
@@ -81,11 +71,6 @@ jobs:
         with:
           toolchain: "1.97"
           targets: ${{ matrix.target }}
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
       - name: Build release tools
         run: cargo build --release --target ${{ matrix.target }} -p omt-studio-monitor -p omt-test-patterns -p capture-spike
       - name: Upload tool artifacts
@@ -106,11 +91,6 @@ jobs:
         with:
           toolchain: "1.97"
           targets: aarch64-pc-windows-msvc
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
       - name: Build Windows Arm64 tools
         run: cargo build --release --target aarch64-pc-windows-msvc -p omt-studio-monitor -p omt-test-patterns -p capture-spike
       - name: Upload tool artifacts
@@ -149,11 +129,6 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.2.19"
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git ../openmediatransport-rs
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git ../vmx-rs
       - name: Ensure sidecar placeholders
         shell: pwsh
         run: ./scripts/ensure-sidecar-placeholders.ps1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -41,12 +41,6 @@ jobs:
         with:
           bun-version: '1.2.19'
 
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
-
       - name: Build sidecar tools
         run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,6 @@ jobs:
         with:
           bun-version: '1.2.19'
 
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
-
       - name: Build sidecar tools
         run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
 

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -38,12 +38,6 @@ jobs:
         with:
           bun-version: '1.2.19'
 
-      - name: Checkout sibling crates
-        shell: bash
-        run: |
-          git clone --depth 1 https://github.com/MikanseiLaboratory/openmediatransport-rs.git "${GITHUB_WORKSPACE}/../openmediatransport-rs"
-          git clone --depth 1 https://github.com/MikanseiLaboratory/vmx-rs.git "${GITHUB_WORKSPACE}/../vmx-rs"
-
       - name: Build sidecar tools
         run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6186,6 +6186,7 @@ dependencies = [
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#a8bc036d878c8aad422f3efe7934f5b7b688a62e"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -9926,6 +9927,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vmx"
 version = "0.1.0"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs#6cf175070b372b77cd52236aca3b5da18439af85"
 dependencies = [
  "rayon",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ suite-core = { path = "crates/suite-core" }
 omt-media = { path = "crates/omt-media" }
 pattern-generator = { path = "crates/pattern-generator" }
 monitor-bench = { path = "crates/monitor-bench" }
-openmediatransport = { path = "../openmediatransport-rs", features = ["tokio"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", features = ["tokio"] }
 gpui = "0.2.2"
-vmx = { path = "../vmx-rs" }
+vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs" }
 anyhow = "1"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github
 
 - Rust **1.97+** (edition 2024)
 - Bun 1.2+ (launcher frontend)
-- Sibling checkouts:
-  - `../openmediatransport-rs`
-  - `../vmx-rs`
 
 ## Develop
 


### PR DESCRIPTION
## Summary
- Switch workspace `openmediatransport` / `vmx` deps from local sibling paths to GitHub git sources
- Drop CI/release sibling clone steps (Cargo fetches the git dependencies)
- Remove sibling checkout prerequisite from README

## Test plan
- [ ] `cargo check -p omt-media -p omt-studio-monitor -p omt-test-patterns` works without local sibling checkouts
- [ ] CI fmt / clippy / test / build-tools jobs pass
- [ ] Test Build / release workflows no longer clone sibling crates
