### PR TITLE
Fix install path, Studio Monitor font/fullscreen, and Docs button

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,33 @@ Open Media Transport production utilities inspired by NDI Tools.
 
 Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs).
 
+## Docs & Guides
+
+The launcher **Docs & Guides** button opens this section.
+
+- [Studio Monitor](#studio-monitor) — browse LAN OMT sources, fullscreen preview
+- [Test Patterns](#test-patterns) — send SMPTE-style patterns + tone
+- [Windows install path](#install-destination-windows)
+
+A [project wiki](https://github.com/MikanseiLaboratory/omt-tools/wiki) can host longer guides once pages are added.
+
+### Studio Monitor
+
+- Discover and view OMT sources on the LAN
+- Fullscreen: toolbar button, **F11**, or double-click the preview (Esc / click / F11 to exit)
+- Preferences cover language, theme, audio device, buffer delay, and quality
+
+### Test Patterns
+
+- Send SMPTE-style patterns and tone over OMT from the companion tool launched by the suite
+
+## Install destination (Windows)
+
+Windows installers place the suite under a MikanseiLaboratory folder (same layout as [vmix-utility](https://github.com/MikanseiLaboratory/vmix-utility)):
+
+- Per-machine: `C:\Program Files\MikanseiLaboratory\OMT Tools`
+- Per-user: `%LOCALAPPDATA%\MikanseiLaboratory\OMT Tools`
+
 ## Prerequisites
 
 - Rust **1.97+** (edition 2024)

--- a/README.md
+++ b/README.md
@@ -17,33 +17,6 @@ Open Media Transport production utilities inspired by NDI Tools.
 
 Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs).
 
-## Docs & Guides
-
-The launcher **Docs & Guides** button opens this section.
-
-- [Studio Monitor](#studio-monitor) — browse LAN OMT sources, fullscreen preview
-- [Test Patterns](#test-patterns) — send SMPTE-style patterns + tone
-- [Windows install path](#install-destination-windows)
-
-A [project wiki](https://github.com/MikanseiLaboratory/omt-tools/wiki) can host longer guides once pages are added.
-
-### Studio Monitor
-
-- Discover and view OMT sources on the LAN
-- Fullscreen: toolbar button, **F11**, or double-click the preview (Esc / click / F11 to exit)
-- Preferences cover language, theme, audio device, buffer delay, and quality
-
-### Test Patterns
-
-- Send SMPTE-style patterns and tone over OMT from the companion tool launched by the suite
-
-## Install destination (Windows)
-
-Windows installers place the suite under a MikanseiLaboratory folder (same layout as [vmix-utility](https://github.com/MikanseiLaboratory/vmix-utility)):
-
-- Per-machine: `C:\Program Files\MikanseiLaboratory\OMT Tools`
-- Per-user: `%LOCALAPPDATA%\MikanseiLaboratory\OMT Tools`
-
 ## Prerequisites
 
 - Rust **1.97+** (edition 2024)

--- a/apps/launcher/src-tauri/tauri.conf.json
+++ b/apps/launcher/src-tauri/tauri.conf.json
@@ -40,6 +40,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "MikanseiLaboratory",
     "createUpdaterArtifacts": true,
     "externalBin": [
       "binaries/omt-studio-monitor",
@@ -54,7 +55,14 @@
     ],
     "windows": {
       "digestAlgorithm": "sha256",
-      "certificateThumbprint": null
+      "certificateThumbprint": null,
+      "wix": {
+        "template": "./windows/main.wxs"
+      },
+      "nsis": {
+        "template": "./windows/installer.nsi",
+        "installMode": "both"
+      }
     },
     "macOS": {
       "minimumSystemVersion": "11.0"

--- a/apps/launcher/src-tauri/windows/installer.nsi
+++ b/apps/launcher/src-tauri/windows/installer.nsi
@@ -1,0 +1,973 @@
+Unicode true
+ManifestDPIAware true
+; Add in `dpiAwareness` `PerMonitorV2` to manifest for Windows 10 1607+ (note this should not affect lower versions since they should be able to ignore this and pick up `dpiAware` `true` set by `ManifestDPIAware true`)
+; Currently undocumented on NSIS's website but is in the Docs folder of source tree, see
+; https://github.com/kichik/nsis/blob/5fc0b87b819a9eec006df4967d08e522ddd651c9/Docs/src/attributes.but#L286-L300
+; https://github.com/tauri-apps/tauri/pull/10106
+ManifestDPIAwareness PerMonitorV2
+
+!if "{{compression}}" == "none"
+  SetCompress off
+!else
+  ; Set the compression algorithm. We default to LZMA.
+  SetCompressor /SOLID "{{compression}}"
+!endif
+
+!include MUI2.nsh
+!include FileFunc.nsh
+!include x64.nsh
+!include WordFunc.nsh
+!include "utils.nsh"
+!include "FileAssociation.nsh"
+!include "Win\COM.nsh"
+!include "Win\Propkey.nsh"
+!include "StrFunc.nsh"
+${StrCase}
+${StrLoc}
+
+{{#if installer_hooks}}
+!include "{{installer_hooks}}"
+{{/if}}
+
+!define WEBVIEW2APPGUID "{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}"
+
+!define MANUFACTURER "{{manufacturer}}"
+!define PRODUCTNAME "{{product_name}}"
+!define VERSION "{{version}}"
+!define VERSIONWITHBUILD "{{version_with_build}}"
+!define HOMEPAGE "{{homepage}}"
+!define INSTALLMODE "{{install_mode}}"
+!define LICENSE "{{license}}"
+!define INSTALLERICON "{{installer_icon}}"
+!define SIDEBARIMAGE "{{sidebar_image}}"
+!define HEADERIMAGE "{{header_image}}"
+!define UNINSTALLERICON "{{uninstaller_icon}}"
+!define UNINSTALLERHEADERIMAGE "{{uninstaller_header_image}}"
+!define MAINBINARYNAME "{{main_binary_name}}"
+!define MAINBINARYSRCPATH "{{main_binary_path}}"
+!define BUNDLEID "{{bundle_id}}"
+!define COPYRIGHT "{{copyright}}"
+!define OUTFILE "{{out_file}}"
+!define ARCH "{{arch}}"
+!define ADDITIONALPLUGINSPATH "{{additional_plugins_path}}"
+!define ALLOWDOWNGRADES "{{allow_downgrades}}"
+!define DISPLAYLANGUAGESELECTOR "{{display_language_selector}}"
+!define INSTALLWEBVIEW2MODE "{{install_webview2_mode}}"
+!define WEBVIEW2INSTALLERARGS "{{webview2_installer_args}}"
+!define WEBVIEW2BOOTSTRAPPERPATH "{{webview2_bootstrapper_path}}"
+!define WEBVIEW2INSTALLERPATH "{{webview2_installer_path}}"
+!define MINIMUMWEBVIEW2VERSION "{{minimum_webview2_version}}"
+!define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCTNAME}"
+!define MANUKEY "Software\${MANUFACTURER}"
+!define MANUPRODUCTKEY "${MANUKEY}\${PRODUCTNAME}"
+!define UNINSTALLERSIGNCOMMAND "{{uninstaller_sign_cmd}}"
+!define ESTIMATEDSIZE "{{estimated_size}}"
+!define STARTMENUFOLDER "{{start_menu_folder}}"
+
+Var PassiveMode
+Var UpdateMode
+Var NoShortcutMode
+Var WixMode
+Var OldMainBinaryName
+
+Name "${PRODUCTNAME}"
+BrandingText "${COPYRIGHT}"
+OutFile "${OUTFILE}"
+
+; We don't actually use this value as default install path,
+; it's just for nsis to append the product name folder in the directory selector
+; https://nsis.sourceforge.io/Reference/InstallDir
+!define INSTALL_PARENT_DIR "MikanseiLaboratory"
+!define INSTALL_RELATIVE_PATH "${INSTALL_PARENT_DIR}\${PRODUCTNAME}"
+!define PLACEHOLDER_INSTALL_DIR "placeholder\${INSTALL_RELATIVE_PATH}"
+InstallDir "${PLACEHOLDER_INSTALL_DIR}"
+
+VIProductVersion "${VERSIONWITHBUILD}"
+VIAddVersionKey "ProductName" "${PRODUCTNAME}"
+VIAddVersionKey "FileDescription" "${PRODUCTNAME}"
+VIAddVersionKey "LegalCopyright" "${COPYRIGHT}"
+VIAddVersionKey "FileVersion" "${VERSION}"
+VIAddVersionKey "ProductVersion" "${VERSION}"
+
+# additional plugins
+!addplugindir "${ADDITIONALPLUGINSPATH}"
+
+; Uninstaller signing command
+!if "${UNINSTALLERSIGNCOMMAND}" != ""
+  !uninstfinalize '${UNINSTALLERSIGNCOMMAND}'
+!endif
+
+; Handle install mode, `perUser`, `perMachine` or `both`
+!if "${INSTALLMODE}" == "perMachine"
+  RequestExecutionLevel admin
+!endif
+
+!if "${INSTALLMODE}" == "currentUser"
+  RequestExecutionLevel user
+!endif
+
+!if "${INSTALLMODE}" == "both"
+  !define MULTIUSER_MUI
+  !define MULTIUSER_INSTALLMODE_INSTDIR "${INSTALL_RELATIVE_PATH}"
+  !define MULTIUSER_INSTALLMODE_COMMANDLINE
+  !if "${ARCH}" == "x64"
+    !define MULTIUSER_USE_PROGRAMFILES64
+  !else if "${ARCH}" == "arm64"
+    !define MULTIUSER_USE_PROGRAMFILES64
+  !endif
+  !define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_KEY "${UNINSTKEY}"
+  !define MULTIUSER_INSTALLMODE_DEFAULT_REGISTRY_VALUENAME "CurrentUser"
+  !define MULTIUSER_INSTALLMODEPAGE_SHOWUSERNAME
+  !define MULTIUSER_INSTALLMODE_FUNCTION RestorePreviousInstallLocation
+  !define MULTIUSER_EXECUTIONLEVEL Highest
+  !include MultiUser.nsh
+!endif
+
+; Installer icon
+!if "${INSTALLERICON}" != ""
+  !define MUI_ICON "${INSTALLERICON}"
+!endif
+
+; Installer sidebar image
+!if "${SIDEBARIMAGE}" != ""
+  !define MUI_WELCOMEFINISHPAGE_BITMAP "${SIDEBARIMAGE}"
+!endif
+
+; Enable header images for installer and uninstaller pages when either image is configured.
+!if "${HEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE
+!else if "${UNINSTALLERHEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE
+!endif
+
+; Installer header image
+!if "${HEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE_BITMAP "${HEADERIMAGE}"
+!endif
+
+; Uninstaller header image
+!if "${UNINSTALLERHEADERIMAGE}" != ""
+  !define MUI_HEADERIMAGE_UNBITMAP "${UNINSTALLERHEADERIMAGE}"
+!endif
+
+; Uninstaller icon
+!if "${UNINSTALLERICON}" != ""
+  !define MUI_UNICON "${UNINSTALLERICON}"
+!endif
+
+; Define registry key to store installer language
+!define MUI_LANGDLL_REGISTRY_ROOT "HKCU"
+!define MUI_LANGDLL_REGISTRY_KEY "${MANUPRODUCTKEY}"
+!define MUI_LANGDLL_REGISTRY_VALUENAME "Installer Language"
+
+; Installer pages, must be ordered as they appear
+; 1. Welcome Page
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_WELCOME
+
+; 2. License Page (if defined)
+!if "${LICENSE}" != ""
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+  !insertmacro MUI_PAGE_LICENSE "${LICENSE}"
+!endif
+
+; 3. Install mode (if it is set to `both`)
+!if "${INSTALLMODE}" == "both"
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+  !insertmacro MULTIUSER_PAGE_INSTALLMODE
+!endif
+
+; 4. Custom page to ask user if he wants to reinstall/uninstall
+;    only if a previous installation was detected
+Var ReinstallPageCheck
+Page custom PageReinstall PageLeaveReinstall
+Function PageReinstall
+  ; Uninstall previous WiX installation if exists.
+  ;
+  ; A WiX installer stores the installation info in registry
+  ; using a UUID and so we have to loop through all keys under
+  ; `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`
+  ; and check if `DisplayName` and `Publisher` keys match ${PRODUCTNAME} and ${MANUFACTURER}
+  ;
+  ; This has a potential issue that there maybe another installation that matches
+  ; our ${PRODUCTNAME} and ${MANUFACTURER} but wasn't installed by our WiX installer,
+  ; however, this should be fine since the user will have to confirm the uninstallation
+  ; and they can chose to abort it if doesn't make sense.
+  StrCpy $0 0
+  wix_loop:
+    EnumRegKey $1 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" $0
+    StrCmp $1 "" wix_loop_done ; Exit loop if there is no more keys to loop on
+    IntOp $0 $0 + 1
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "DisplayName"
+    ReadRegStr $R1 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "Publisher"
+    StrCmp "$R0$R1" "${PRODUCTNAME}${MANUFACTURER}" 0 wix_loop
+    ReadRegStr $R0 HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1" "UninstallString"
+    ${StrCase} $R1 $R0 "L"
+    ${StrLoc} $R0 $R1 "msiexec" ">"
+    StrCmp $R0 0 0 wix_loop_done
+    StrCpy $WixMode 1
+    StrCpy $R6 "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$1"
+    Goto compare_version
+  wix_loop_done:
+
+  ; Check if there is an existing installation, if not, abort the reinstall page
+  ReadRegStr $R0 SHCTX "${UNINSTKEY}" ""
+  ReadRegStr $R1 SHCTX "${UNINSTKEY}" "UninstallString"
+  ${IfThen} "$R0$R1" == "" ${|} Abort ${|}
+
+  ; Compare this installar version with the existing installation
+  ; and modify the messages presented to the user accordingly
+  compare_version:
+  StrCpy $R4 "$(older)"
+  ${If} $WixMode = 1
+    ReadRegStr $R0 HKLM "$R6" "DisplayVersion"
+  ${Else}
+    ReadRegStr $R0 SHCTX "${UNINSTKEY}" "DisplayVersion"
+  ${EndIf}
+  ${IfThen} $R0 == "" ${|} StrCpy $R4 "$(unknown)" ${|}
+
+  nsis_tauri_utils::SemverCompare "${VERSION}" $R0
+  Pop $R0
+  ; Reinstalling the same version
+  ${If} $R0 = 0
+    StrCpy $R1 "$(alreadyInstalledLong)"
+    StrCpy $R2 "$(addOrReinstall)"
+    StrCpy $R3 "$(uninstallApp)"
+    !insertmacro MUI_HEADER_TEXT "$(alreadyInstalled)" "$(chooseMaintenanceOption)"
+  ; Upgrading
+  ${ElseIf} $R0 = 1
+    StrCpy $R1 "$(olderOrUnknownVersionInstalled)"
+    StrCpy $R2 "$(uninstallBeforeInstalling)"
+    StrCpy $R3 "$(dontUninstall)"
+    !insertmacro MUI_HEADER_TEXT "$(alreadyInstalled)" "$(choowHowToInstall)"
+  ; Downgrading
+  ${ElseIf} $R0 = -1
+    StrCpy $R1 "$(newerVersionInstalled)"
+    StrCpy $R2 "$(uninstallBeforeInstalling)"
+    !if "${ALLOWDOWNGRADES}" == "true"
+      StrCpy $R3 "$(dontUninstall)"
+    !else
+      StrCpy $R3 "$(dontUninstallDowngrade)"
+    !endif
+    !insertmacro MUI_HEADER_TEXT "$(alreadyInstalled)" "$(choowHowToInstall)"
+  ${Else}
+    Abort
+  ${EndIf}
+
+  ; Skip showing the page if passive
+  ;
+  ; Note that we don't call this earlier at the begining
+  ; of this function because we need to populate some variables
+  ; related to current installed version if detected and whether
+  ; we are downgrading or not.
+  ${If} $PassiveMode = 1
+    Call PageLeaveReinstall
+  ${Else}
+    nsDialogs::Create 1018
+    Pop $R4
+    ${IfThen} $(^RTL) = 1 ${|} nsDialogs::SetRTL $(^RTL) ${|}
+
+    ${NSD_CreateLabel} 0 0 100% 24u $R1
+    Pop $R1
+
+    ${NSD_CreateRadioButton} 30u 50u -30u 8u $R2
+    Pop $R2
+    ${NSD_OnClick} $R2 PageReinstallUpdateSelection
+
+    ${NSD_CreateRadioButton} 30u 70u -30u 8u $R3
+    Pop $R3
+    ; Disable this radio button if downgrading and downgrades are disabled
+    !if "${ALLOWDOWNGRADES}" == "false"
+      ${IfThen} $R0 = -1 ${|} EnableWindow $R3 0 ${|}
+    !endif
+    ${NSD_OnClick} $R3 PageReinstallUpdateSelection
+
+    ; Check the first radio button if this the first time
+    ; we enter this page or if the second button wasn't
+    ; selected the last time we were on this page
+    ${If} $ReinstallPageCheck <> 2
+      SendMessage $R2 ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${Else}
+      SendMessage $R3 ${BM_SETCHECK} ${BST_CHECKED} 0
+    ${EndIf}
+
+    ${NSD_SetFocus} $R2
+    nsDialogs::Show
+  ${EndIf}
+FunctionEnd
+Function PageReinstallUpdateSelection
+  ${NSD_GetState} $R2 $R1
+  ${If} $R1 == ${BST_CHECKED}
+    StrCpy $ReinstallPageCheck 1
+  ${Else}
+    StrCpy $ReinstallPageCheck 2
+  ${EndIf}
+FunctionEnd
+Function PageLeaveReinstall
+  ${NSD_GetState} $R2 $R1
+
+  ; If migrating from Wix, always uninstall
+  ${If} $WixMode = 1
+    Goto reinst_uninstall
+  ${EndIf}
+
+  ; In update mode, always proceeds without uninstalling
+  ${If} $UpdateMode = 1
+    Goto reinst_done
+  ${EndIf}
+
+  ; $R0 holds whether same(0)/upgrading(1)/downgrading(-1) version
+  ; $R1 holds the radio buttons state:
+  ;   1 => first choice was selected
+  ;   0 => second choice was selected
+  ${If} $R0 = 0 ; Same version, proceed
+    ${If} $R1 = 1              ; User chose to add/reinstall
+      Goto reinst_done
+    ${Else}                    ; User chose to uninstall
+      Goto reinst_uninstall
+    ${EndIf}
+  ${ElseIf} $R0 = 1 ; Upgrading
+    ${If} $R1 = 1              ; User chose to uninstall
+      Goto reinst_uninstall
+    ${Else}
+      Goto reinst_done         ; User chose NOT to uninstall
+    ${EndIf}
+  ${ElseIf} $R0 = -1 ; Downgrading
+    ${If} $R1 = 1              ; User chose to uninstall
+      Goto reinst_uninstall
+    ${Else}
+      Goto reinst_done         ; User chose NOT to uninstall
+    ${EndIf}
+  ${EndIf}
+
+  reinst_uninstall:
+    HideWindow
+    ClearErrors
+
+    ${If} $WixMode = 1
+      ReadRegStr $R1 HKLM "$R6" "UninstallString"
+      ExecWait '$R1' $0
+    ${Else}
+      ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
+      ReadRegStr $R1 SHCTX "${UNINSTKEY}" "UninstallString"
+      ${IfThen} $UpdateMode = 1 ${|} StrCpy $R1 "$R1 /UPDATE" ${|} ; append /UPDATE
+      ${IfThen} $PassiveMode = 1 ${|} StrCpy $R1 "$R1 /P" ${|} ; append /P
+      StrCpy $R1 "$R1 _?=$4" ; append uninstall directory
+      ExecWait '$R1' $0
+    ${EndIf}
+
+    BringToFront
+
+    ${IfThen} ${Errors} ${|} StrCpy $0 2 ${|} ; ExecWait failed, set fake exit code
+
+    ${If} $0 <> 0
+    ${OrIf} ${FileExists} "$INSTDIR\${MAINBINARYNAME}.exe"
+      ; User cancelled wix uninstaller? return to select un/reinstall page
+      ${If} $WixMode = 1
+      ${AndIf} $0 = 1602
+        Abort
+      ${EndIf}
+
+      ; User cancelled NSIS uninstaller? return to select un/reinstall page
+      ${If} $0 = 1
+        Abort
+      ${EndIf}
+
+      ; Other erros? show generic error message and return to select un/reinstall page
+      MessageBox MB_ICONEXCLAMATION "$(unableToUninstall)"
+      Abort
+    ${EndIf}
+  reinst_done:
+FunctionEnd
+
+; 5. Choose install directory page
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_DIRECTORY
+
+; 6. Start menu shortcut page
+Var AppStartMenuFolder
+!if "${STARTMENUFOLDER}" != ""
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+  !define MUI_STARTMENUPAGE_DEFAULTFOLDER "${STARTMENUFOLDER}"
+!else
+  !define MUI_PAGE_CUSTOMFUNCTION_PRE Skip
+!endif
+!insertmacro MUI_PAGE_STARTMENU Application $AppStartMenuFolder
+
+; 7. Installation page
+!insertmacro MUI_PAGE_INSTFILES
+
+; 8. Finish page
+;
+; Don't auto jump to finish page after installation page,
+; because the installation page has useful info that can be used debug any issues with the installer.
+!define MUI_FINISHPAGE_NOAUTOCLOSE
+; Use show readme button in the finish page as a button create a desktop shortcut
+!define MUI_FINISHPAGE_SHOWREADME
+!define MUI_FINISHPAGE_SHOWREADME_TEXT "$(createDesktop)"
+!define MUI_FINISHPAGE_SHOWREADME_FUNCTION CreateOrUpdateDesktopShortcut
+; Show run app after installation.
+!define MUI_FINISHPAGE_RUN
+!define MUI_FINISHPAGE_RUN_FUNCTION RunMainBinary
+!define MUI_PAGE_CUSTOMFUNCTION_PRE SkipIfPassive
+!insertmacro MUI_PAGE_FINISH
+
+Function RunMainBinary
+  nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" ""
+FunctionEnd
+
+; Uninstaller Pages
+; 1. Confirm uninstall page
+Var DeleteAppDataCheckbox
+Var DeleteAppDataCheckboxState
+!define /ifndef WS_EX_LAYOUTRTL         0x00400000
+!define MUI_PAGE_CUSTOMFUNCTION_SHOW un.ConfirmShow
+Function un.ConfirmShow ; Add add a `Delete app data` check box
+  ; $1 inner dialog HWND
+  ; $2 window DPI
+  ; $3 style
+  ; $4 x
+  ; $5 y
+  ; $6 width
+  ; $7 height
+  FindWindow $1 "#32770" "" $HWNDPARENT ; Find inner dialog
+  System::Call "user32::GetDpiForWindow(p r1) i .r2"
+  ${If} $(^RTL) = 1
+    StrCpy $3 "${__NSD_CheckBox_EXSTYLE} | ${WS_EX_LAYOUTRTL}"
+    IntOp $4 50 * $2
+  ${Else}
+    StrCpy $3 "${__NSD_CheckBox_EXSTYLE}"
+    IntOp $4 0 * $2
+  ${EndIf}
+  IntOp $5 100 * $2
+  IntOp $6 400 * $2
+  IntOp $7 25 * $2
+  IntOp $4 $4 / 96
+  IntOp $5 $5 / 96
+  IntOp $6 $6 / 96
+  IntOp $7 $7 / 96
+  System::Call 'user32::CreateWindowEx(i r3, w "${__NSD_CheckBox_CLASS}", w "$(deleteAppData)", i ${__NSD_CheckBox_STYLE}, i r4, i r5, i r6, i r7, p r1, i0, i0, i0) i .s'
+  Pop $DeleteAppDataCheckbox
+  SendMessage $HWNDPARENT ${WM_GETFONT} 0 0 $1
+  SendMessage $DeleteAppDataCheckbox ${WM_SETFONT} $1 1
+FunctionEnd
+!define MUI_PAGE_CUSTOMFUNCTION_LEAVE un.ConfirmLeave
+Function un.ConfirmLeave
+  SendMessage $DeleteAppDataCheckbox ${BM_GETCHECK} 0 0 $DeleteAppDataCheckboxState
+FunctionEnd
+!define MUI_PAGE_CUSTOMFUNCTION_PRE un.SkipIfPassive
+!insertmacro MUI_UNPAGE_CONFIRM
+
+; 2. Uninstalling Page
+!insertmacro MUI_UNPAGE_INSTFILES
+
+;Languages
+{{#each languages}}
+!insertmacro MUI_LANGUAGE "{{this}}"
+{{/each}}
+!insertmacro MUI_RESERVEFILE_LANGDLL
+{{#each language_files}}
+  !include "{{this}}"
+{{/each}}
+
+Function .onInit
+  ${GetOptions} $CMDLINE "/P" $PassiveMode
+  ${IfNot} ${Errors}
+    StrCpy $PassiveMode 1
+  ${EndIf}
+
+  ${GetOptions} $CMDLINE "/NS" $NoShortcutMode
+  ${IfNot} ${Errors}
+    StrCpy $NoShortcutMode 1
+  ${EndIf}
+
+  ${GetOptions} $CMDLINE "/UPDATE" $UpdateMode
+  ${IfNot} ${Errors}
+    StrCpy $UpdateMode 1
+  ${EndIf}
+
+  !if "${DISPLAYLANGUAGESELECTOR}" == "true"
+    !insertmacro MUI_LANGDLL_DISPLAY
+  !endif
+
+  !insertmacro SetContext
+
+  ${If} $INSTDIR == "${PLACEHOLDER_INSTALL_DIR}"
+    ; Set default install location
+    !if "${INSTALLMODE}" == "perMachine"
+      ${If} ${RunningX64}
+        !if "${ARCH}" == "x64"
+          StrCpy $INSTDIR "$PROGRAMFILES64\${INSTALL_RELATIVE_PATH}"
+        !else if "${ARCH}" == "arm64"
+          StrCpy $INSTDIR "$PROGRAMFILES64\${INSTALL_RELATIVE_PATH}"
+        !else
+          StrCpy $INSTDIR "$PROGRAMFILES\${INSTALL_RELATIVE_PATH}"
+        !endif
+      ${Else}
+        StrCpy $INSTDIR "$PROGRAMFILES\${INSTALL_RELATIVE_PATH}"
+      ${EndIf}
+    !else if "${INSTALLMODE}" == "currentUser"
+      StrCpy $INSTDIR "$LOCALAPPDATA\${INSTALL_RELATIVE_PATH}"
+    !endif
+
+    Call RestorePreviousInstallLocation
+  ${EndIf}
+
+
+  !if "${INSTALLMODE}" == "both"
+    !insertmacro MULTIUSER_INIT
+  !endif
+FunctionEnd
+
+
+Section EarlyChecks
+  ; Abort silent installer if downgrades is disabled
+  !if "${ALLOWDOWNGRADES}" == "false"
+  ${If} ${Silent}
+    ; If downgrading
+    ${If} $R0 = -1
+      System::Call 'kernel32::AttachConsole(i -1)i.r0'
+      ${If} $0 <> 0
+        System::Call 'kernel32::GetStdHandle(i -11)i.r0'
+        System::call 'kernel32::SetConsoleTextAttribute(i r0, i 0x0004)' ; set red color
+        FileWrite $0 "$(silentDowngrades)"
+      ${EndIf}
+      Abort
+    ${EndIf}
+  ${EndIf}
+  !endif
+
+SectionEnd
+
+Section WebView2
+  ; Check if Webview2 is already installed and skip this section
+  ${If} ${RunningX64}
+    ReadRegStr $4 HKLM "SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
+  ${Else}
+    ReadRegStr $4 HKLM "SOFTWARE\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
+  ${EndIf}
+  ${If} $4 == ""
+    ReadRegStr $4 HKCU "SOFTWARE\Microsoft\EdgeUpdate\Clients\${WEBVIEW2APPGUID}" "pv"
+  ${EndIf}
+
+  ${If} $4 == ""
+    ; Webview2 installation
+    ;
+    ; Skip if updating
+    ${If} $UpdateMode <> 1
+      !if "${INSTALLWEBVIEW2MODE}" == "downloadBootstrapper"
+        Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        DetailPrint "$(webview2Downloading)"
+        NSISdl::download "https://go.microsoft.com/fwlink/p/?LinkId=2124703" "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        Pop $0
+        ${If} $0 == "success"
+          DetailPrint "$(webview2DownloadSuccess)"
+        ${Else}
+          DetailPrint "$(webview2DownloadError)"
+          Abort "$(webview2AbortError)"
+        ${EndIf}
+        StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        Goto install_webview2
+      !endif
+
+      !if "${INSTALLWEBVIEW2MODE}" == "embedBootstrapper"
+        Delete "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        File "/oname=$TEMP\MicrosoftEdgeWebview2Setup.exe" "${WEBVIEW2BOOTSTRAPPERPATH}"
+        DetailPrint "$(installingWebview2)"
+        StrCpy $6 "$TEMP\MicrosoftEdgeWebview2Setup.exe"
+        Goto install_webview2
+      !endif
+
+      !if "${INSTALLWEBVIEW2MODE}" == "offlineInstaller"
+        Delete "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
+        File "/oname=$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe" "${WEBVIEW2INSTALLERPATH}"
+        DetailPrint "$(installingWebview2)"
+        StrCpy $6 "$TEMP\MicrosoftEdgeWebView2RuntimeInstaller.exe"
+        Goto install_webview2
+      !endif
+
+      Goto webview2_done
+
+      install_webview2:
+        DetailPrint "$(installingWebview2)"
+        ; $6 holds the path to the webview2 installer
+        ExecWait "$6 ${WEBVIEW2INSTALLERARGS} /install" $1
+        ${If} $1 = 0
+          DetailPrint "$(webview2InstallSuccess)"
+        ${Else}
+          DetailPrint "$(webview2InstallError)"
+          Abort "$(webview2AbortError)"
+        ${EndIf}
+      webview2_done:
+    ${EndIf}
+  ${Else}
+    !if "${MINIMUMWEBVIEW2VERSION}" != ""
+      ${VersionCompare} "${MINIMUMWEBVIEW2VERSION}" "$4" $R0
+      ${If} $R0 = 1
+        update_webview:
+          DetailPrint "$(installingWebview2)"
+          ${If} ${RunningX64}
+            ReadRegStr $R1 HKLM "SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" "path"
+          ${Else}
+            ReadRegStr $R1 HKLM "SOFTWARE\Microsoft\EdgeUpdate" "path"
+          ${EndIf}
+          ${If} $R1 == ""
+            ReadRegStr $R1 HKCU "SOFTWARE\Microsoft\EdgeUpdate" "path"
+          ${EndIf}
+          ${If} $R1 != ""
+            ; Chromium updater docs: https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/user_manual.md
+            ; Modified from "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView\ModifyPath"
+            ExecWait `"$R1" /install appguid=${WEBVIEW2APPGUID}&needsadmin=true` $1
+            ${If} $1 = 0
+              DetailPrint "$(webview2InstallSuccess)"
+            ${Else}
+              MessageBox MB_ICONEXCLAMATION|MB_ABORTRETRYIGNORE "$(webview2InstallError)" IDIGNORE ignore IDRETRY update_webview
+              Quit
+              ignore:
+            ${EndIf}
+          ${EndIf}
+      ${EndIf}
+    !endif
+  ${EndIf}
+SectionEnd
+
+Section Install
+  SetOutPath $INSTDIR
+
+  !ifmacrodef NSIS_HOOK_PREINSTALL
+    !insertmacro NSIS_HOOK_PREINSTALL
+  !endif
+
+  !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+
+  ; Copy main executable
+  File "${MAINBINARYSRCPATH}"
+
+  ; Copy resources
+  {{#each resources_dirs}}
+    CreateDirectory "$INSTDIR\\{{this}}"
+  {{/each}}
+  {{#each resources}}
+    File /a "/oname={{this.[1]}}" "{{no-escape @key}}"
+  {{/each}}
+
+  ; Copy external binaries
+  {{#each binaries}}
+    File /a "/oname={{this}}" "{{no-escape @key}}"
+  {{/each}}
+
+  ; Create file associations
+  {{#each file_associations as |association| ~}}
+    {{#each association.ext as |ext| ~}}
+       !insertmacro APP_ASSOCIATE "{{ext}}" "{{or association.name ext}}" "{{association-description association.description ext}}" "$INSTDIR\${MAINBINARYNAME}.exe,0" "Open with ${PRODUCTNAME}" "$INSTDIR\${MAINBINARYNAME}.exe $\"%1$\""
+    {{/each}}
+  {{/each}}
+
+  ; Register deep links
+  {{#each deep_link_protocols as |protocol| ~}}
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}" "URL Protocol" ""
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}" "" "URL:${BUNDLEID} protocol"
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}\DefaultIcon" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\",0"
+    WriteRegStr SHCTX "Software\Classes\\{{protocol}}\shell\open\command" "" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+  {{/each}}
+
+  ; Create uninstaller
+  WriteUninstaller "$INSTDIR\uninstall.exe"
+
+  ; Save $INSTDIR in registry for future installations
+  WriteRegStr SHCTX "${MANUPRODUCTKEY}" "" $INSTDIR
+
+  !if "${INSTALLMODE}" == "both"
+    ; Save install mode to be selected by default for the next installation such as updating
+    ; or when uninstalling
+    WriteRegStr SHCTX "${UNINSTKEY}" $MultiUser.InstallMode 1
+  !endif
+
+  ; Remove old main binary if it doesn't match new main binary name
+  ReadRegStr $OldMainBinaryName SHCTX "${UNINSTKEY}" "MainBinaryName"
+  ${If} $OldMainBinaryName != ""
+  ${AndIf} $OldMainBinaryName != "${MAINBINARYNAME}.exe"
+    Delete "$INSTDIR\$OldMainBinaryName"
+  ${EndIf}
+
+  ; Save current MAINBINARYNAME for future updates
+  WriteRegStr SHCTX "${UNINSTKEY}" "MainBinaryName" "${MAINBINARYNAME}.exe"
+
+  ; Registry information for add/remove programs
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayName" "${PRODUCTNAME}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayIcon" "$\"$INSTDIR\${MAINBINARYNAME}.exe$\""
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayVersion" "${VERSION}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "Publisher" "${MANUFACTURER}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "InstallLocation" "$\"$INSTDIR$\""
+  WriteRegStr SHCTX "${UNINSTKEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "NoModify" "1"
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "NoRepair" "1"
+
+  ${GetSize} "$INSTDIR" "/M=uninstall.exe /S=0K /G=0" $0 $1 $2
+  IntOp $0 $0 + ${ESTIMATEDSIZE}
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "EstimatedSize" "$0"
+
+  !if "${HOMEPAGE}" != ""
+    WriteRegStr SHCTX "${UNINSTKEY}" "URLInfoAbout" "${HOMEPAGE}"
+    WriteRegStr SHCTX "${UNINSTKEY}" "URLUpdateInfo" "${HOMEPAGE}"
+    WriteRegStr SHCTX "${UNINSTKEY}" "HelpLink" "${HOMEPAGE}"
+  !endif
+
+  ; Create start menu shortcut
+  !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
+    Call CreateOrUpdateStartMenuShortcut
+  !insertmacro MUI_STARTMENU_WRITE_END
+
+  ; Create desktop shortcut for silent and passive installers
+  ; because finish page will be skipped
+  ${If} $PassiveMode = 1
+  ${OrIf} ${Silent}
+    Call CreateOrUpdateDesktopShortcut
+  ${EndIf}
+
+  !ifmacrodef NSIS_HOOK_POSTINSTALL
+    !insertmacro NSIS_HOOK_POSTINSTALL
+  !endif
+
+  ; Auto close this page for passive mode
+  ${If} $PassiveMode = 1
+    SetAutoClose true
+  ${EndIf}
+SectionEnd
+
+Function .onInstSuccess
+  ; Check for `/R` flag only in silent and passive installers because
+  ; GUI installer has a toggle for the user to (re)start the app
+  ${If} $PassiveMode = 1
+  ${OrIf} ${Silent}
+    ${GetOptions} $CMDLINE "/R" $R0
+    ${IfNot} ${Errors}
+      ${GetOptions} $CMDLINE "/ARGS" $R0
+      nsis_tauri_utils::RunAsUser "$INSTDIR\${MAINBINARYNAME}.exe" "$R0"
+    ${EndIf}
+  ${EndIf}
+FunctionEnd
+
+Function un.onInit
+  !insertmacro SetContext
+
+  !if "${INSTALLMODE}" == "both"
+    !insertmacro MULTIUSER_UNINIT
+  !endif
+
+  !insertmacro MUI_UNGETLANGUAGE
+
+  ${GetOptions} $CMDLINE "/P" $PassiveMode
+  ${IfNot} ${Errors}
+    StrCpy $PassiveMode 1
+  ${EndIf}
+
+  ${GetOptions} $CMDLINE "/UPDATE" $UpdateMode
+  ${IfNot} ${Errors}
+    StrCpy $UpdateMode 1
+  ${EndIf}
+FunctionEnd
+
+Section Uninstall
+
+  !ifmacrodef NSIS_HOOK_PREUNINSTALL
+    !insertmacro NSIS_HOOK_PREUNINSTALL
+  !endif
+
+  !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+
+  ; Delete the app directory and its content from disk
+  ; Copy main executable
+  Delete "$INSTDIR\${MAINBINARYNAME}.exe"
+
+  ; Delete resources
+  {{#each resources}}
+    Delete "$INSTDIR\\{{this.[1]}}"
+  {{/each}}
+
+  ; Delete external binaries
+  {{#each binaries}}
+    Delete "$INSTDIR\\{{this}}"
+  {{/each}}
+
+  ; Delete app associations
+  {{#each file_associations as |association| ~}}
+    {{#each association.ext as |ext| ~}}
+      !insertmacro APP_UNASSOCIATE "{{ext}}" "{{or association.name ext}}"
+    {{/each}}
+  {{/each}}
+
+  ; Delete deep links
+  {{#each deep_link_protocols as |protocol| ~}}
+    ReadRegStr $R7 SHCTX "Software\Classes\\{{protocol}}\shell\open\command" ""
+    ${If} $R7 == "$\"$INSTDIR\${MAINBINARYNAME}.exe$\" $\"%1$\""
+      DeleteRegKey SHCTX "Software\Classes\\{{protocol}}"
+    ${EndIf}
+  {{/each}}
+
+
+  ; Delete uninstaller
+  Delete "$INSTDIR\uninstall.exe"
+
+  {{#each resources_ancestors}}
+  RMDir /REBOOTOK "$INSTDIR\\{{this}}"
+  {{/each}}
+  RMDir "$INSTDIR"
+
+  ; Remove shortcuts if not updating
+  ${If} $UpdateMode <> 1
+    !insertmacro DeleteAppUserModelId
+
+    ; Remove start menu shortcut
+    !insertmacro MUI_STARTMENU_GETFOLDER Application $AppStartMenuFolder
+    !insertmacro IsShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+      !insertmacro UnpinShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
+      Delete "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
+      RMDir "$SMPROGRAMS\$AppStartMenuFolder"
+    ${EndIf}
+    !insertmacro IsShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+      !insertmacro UnpinShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+      Delete "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+    ${EndIf}
+
+    ; Remove desktop shortcuts
+    !insertmacro IsShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Pop $0
+    ${If} $0 = 1
+      !insertmacro UnpinShortcut "$DESKTOP\${PRODUCTNAME}.lnk"
+      Delete "$DESKTOP\${PRODUCTNAME}.lnk"
+    ${EndIf}
+  ${EndIf}
+
+  ; Remove registry information for add/remove programs
+  !if "${INSTALLMODE}" == "both"
+    DeleteRegKey SHCTX "${UNINSTKEY}"
+  !else if "${INSTALLMODE}" == "perMachine"
+    DeleteRegKey HKLM "${UNINSTKEY}"
+  !else
+    DeleteRegKey HKCU "${UNINSTKEY}"
+  !endif
+
+  ; Removes the Autostart entry for ${PRODUCTNAME} from the HKCU Run key if it exists.
+  ; This ensures the program does not launch automatically after uninstallation if it exists.
+  ; If it doesn't exist, it does nothing.
+  ; We do this when not updating (to preserve the registry value on updates)
+  ${If} $UpdateMode <> 1
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${PRODUCTNAME}"
+  ${EndIf}
+
+  ; Delete app data if the checkbox is selected
+  ; and if not updating
+  ${If} $DeleteAppDataCheckboxState = 1
+  ${AndIf} $UpdateMode <> 1
+    ; Clear the install location $INSTDIR from registry
+    DeleteRegKey SHCTX "${MANUPRODUCTKEY}"
+    DeleteRegKey /ifempty SHCTX "${MANUKEY}"
+
+    ; Clear the install language from registry
+    DeleteRegValue HKCU "${MANUPRODUCTKEY}" "Installer Language"
+    DeleteRegKey /ifempty HKCU "${MANUPRODUCTKEY}"
+    DeleteRegKey /ifempty HKCU "${MANUKEY}"
+
+    SetShellVarContext current
+    RmDir /r "$APPDATA\${BUNDLEID}"
+    RmDir /r "$LOCALAPPDATA\${BUNDLEID}"
+  ${EndIf}
+
+  !ifmacrodef NSIS_HOOK_POSTUNINSTALL
+    !insertmacro NSIS_HOOK_POSTUNINSTALL
+  !endif
+
+  ; Auto close if passive mode or updating
+  ${If} $PassiveMode = 1
+  ${OrIf} $UpdateMode = 1
+    SetAutoClose true
+  ${EndIf}
+SectionEnd
+
+Function RestorePreviousInstallLocation
+  ReadRegStr $4 SHCTX "${MANUPRODUCTKEY}" ""
+  StrCmp $4 "" +2 0
+    StrCpy $INSTDIR $4
+FunctionEnd
+
+Function Skip
+  Abort
+FunctionEnd
+
+Function SkipIfPassive
+  ${IfThen} $PassiveMode = 1  ${|} Abort ${|}
+FunctionEnd
+Function un.SkipIfPassive
+  ${IfThen} $PassiveMode = 1  ${|} Abort ${|}
+FunctionEnd
+
+Function CreateOrUpdateStartMenuShortcut
+  ; We used to use product name as MAINBINARYNAME
+  ; migrate old shortcuts to target the new MAINBINARYNAME
+  StrCpy $R0 0
+
+  !insertmacro IsShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
+  Pop $0
+  ${If} $0 = 1
+    !insertmacro SetShortcutTarget "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    StrCpy $R0 1
+  ${EndIf}
+
+  !insertmacro IsShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
+  Pop $0
+  ${If} $0 = 1
+    !insertmacro SetShortcutTarget "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    StrCpy $R0 1
+  ${EndIf}
+
+  ${If} $R0 = 1
+    Return
+  ${EndIf}
+
+  ; Skip creating shortcut if in update mode or no shortcut mode
+  ; but always create if migrating from wix
+  ${If} $WixMode = 0
+    ${If} $UpdateMode = 1
+    ${OrIf} $NoShortcutMode = 1
+      Return
+    ${EndIf}
+  ${EndIf}
+
+  !if "${STARTMENUFOLDER}" != ""
+    CreateDirectory "$SMPROGRAMS\$AppStartMenuFolder"
+    CreateShortcut "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\$AppStartMenuFolder\${PRODUCTNAME}.lnk"
+  !else
+    CreateShortcut "$SMPROGRAMS\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    !insertmacro SetLnkAppUserModelId "$SMPROGRAMS\${PRODUCTNAME}.lnk"
+  !endif
+FunctionEnd
+
+Function CreateOrUpdateDesktopShortcut
+  ; We used to use product name as MAINBINARYNAME
+  ; migrate old shortcuts to target the new MAINBINARYNAME
+  !insertmacro IsShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\$OldMainBinaryName"
+  Pop $0
+  ${If} $0 = 1
+    !insertmacro SetShortcutTarget "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+    Return
+  ${EndIf}
+
+  ; Skip creating shortcut if in update mode or no shortcut mode
+  ; but always create if migrating from wix
+  ${If} $WixMode = 0
+    ${If} $UpdateMode = 1
+    ${OrIf} $NoShortcutMode = 1
+      Return
+    ${EndIf}
+  ${EndIf}
+
+  CreateShortcut "$DESKTOP\${PRODUCTNAME}.lnk" "$INSTDIR\${MAINBINARYNAME}.exe"
+  !insertmacro SetLnkAppUserModelId "$DESKTOP\${PRODUCTNAME}.lnk"
+FunctionEnd

--- a/apps/launcher/src-tauri/windows/main.wxs
+++ b/apps/launcher/src-tauri/windows/main.wxs
@@ -1,0 +1,383 @@
+<?if $(sys.BUILDARCH)="x86"?>
+    <?define Win64 = "no" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?elseif $(sys.BUILDARCH)="x64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?elseif $(sys.BUILDARCH)="arm64"?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else?>
+    <?error Unsupported value of sys.BUILDARCH=$(sys.BUILDARCH)?>
+<?endif?>
+
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Product
+            Id="*"
+            Name="{{product_name}}"
+            UpgradeCode="{{upgrade_code}}"
+            Language="!(loc.TauriLanguage)"
+            Manufacturer="{{manufacturer}}"
+            Version="{{version}}">
+
+        <Package Id="*"
+                 Keywords="Installer"
+                 InstallerVersion="450"
+                 Languages="0"
+                 Compressed="yes"
+                 InstallScope="perMachine"
+                 SummaryCodepage="!(loc.TauriCodepage)"/>
+
+        <!-- https://docs.microsoft.com/en-us/windows/win32/msi/reinstallmode -->
+        <!-- reinstall all files; rewrite all registry entries; reinstall all shortcuts -->
+        <Property Id="REINSTALLMODE" Value="amus" />
+
+        <!-- Auto launch app after installation, useful for passive mode which usually used in updates -->
+        <Property Id="AUTOLAUNCHAPP" Secure="yes" />
+        <!-- Property to forward cli args to the launched app to not lose those of the pre-update instance -->
+        <Property Id="LAUNCHAPPARGS" Secure="yes" />
+
+        {{#if allow_downgrades}}
+            <MajorUpgrade Schedule="afterInstallInitialize" AllowDowngrades="yes" />
+        {{else}}
+            <MajorUpgrade Schedule="afterInstallInitialize" DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" AllowSameVersionUpgrades="yes" />
+        {{/if}}
+
+        <InstallExecuteSequence>
+            <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
+        </InstallExecuteSequence>
+
+        <Media Id="1" Cabinet="app.cab" EmbedCab="yes" />
+
+        {{#if banner_path}}
+        <WixVariable Id="WixUIBannerBmp" Value="{{banner_path}}" />
+        {{/if}}
+        {{#if dialog_image_path}}
+        <WixVariable Id="WixUIDialogBmp" Value="{{dialog_image_path}}" />
+        {{/if}}
+        {{#if license}}
+        <WixVariable Id="WixUILicenseRtf" Value="{{license}}" />
+        {{/if}}
+
+        <Icon Id="ProductIcon" SourceFile="{{icon_path}}"/>
+        <Property Id="ARPPRODUCTICON" Value="ProductIcon" />
+        <Property Id="ARPNOREPAIR" Value="yes" Secure="yes" />      <!-- Remove repair -->
+        <SetProperty Id="ARPNOMODIFY" Value="1" After="InstallValidate" Sequence="execute"/>
+
+        {{#if homepage}}
+        <Property Id="ARPURLINFOABOUT" Value="{{homepage}}"/>
+        <Property Id="ARPHELPLINK" Value="{{homepage}}"/>
+        <Property Id="ARPURLUPDATEINFO" Value="{{homepage}}"/>
+        {{/if}}
+
+        <!-- NOTE: The order of RegistrySearch elements below matters. In WIX, when multiple
+             RegistrySearch elements are listed under a single Property, the LAST successful
+             match wins. We list the NSIS default-key search first and the MSI InstallDir
+             search second so that the MSI-specific path takes priority when both keys exist. -->
+        <Property Id="INSTALLDIR">
+          <!-- First attempt: Search for the default key value (this is how the nsis installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirNoName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Type="raw" />
+
+          <!-- Second attempt: Search for "InstallDir" which takes priority if found (this is how the msi installer stores the path) -->
+          <RegistrySearch Id="PrevInstallDirWithName" Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="InstallDir" Type="raw" />
+        </Property>
+
+        <!-- launch app checkbox -->
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOXTEXT" Value="!(loc.LaunchApp)" />
+        <Property Id="WIXUI_EXITDIALOGOPTIONALCHECKBOX" Value="1"/>
+        <CustomAction Id="LaunchApplication" Impersonate="yes" FileKey="Path" ExeCommand="[LAUNCHAPPARGS]" Return="asyncNoWait" />
+
+        <UI>
+            <!-- launch app checkbox -->
+            <Publish Dialog="ExitDialog" Control="Finish" Event="DoAction" Value="LaunchApplication">WIXUI_EXITDIALOGOPTIONALCHECKBOX = 1 and NOT Installed</Publish>
+
+            <Property Id="WIXUI_INSTALLDIR" Value="INSTALLDIR" />
+
+            {{#unless license}}
+            <!-- Skip license dialog -->
+            <Publish Dialog="WelcomeDlg"
+                     Control="Next"
+                     Event="NewDialog"
+                     Value="InstallDirDlg"
+                     Order="2">1</Publish>
+            <Publish Dialog="InstallDirDlg"
+                     Control="Back"
+                     Event="NewDialog"
+                     Value="WelcomeDlg"
+                     Order="2">1</Publish>
+            {{/unless}}
+        </UI>
+
+        <UIRef Id="WixUI_InstallDir" />
+
+        <Directory Id="TARGETDIR" Name="SourceDir">
+            <Directory Id="DesktopFolder" Name="Desktop">
+                <Component Id="ApplicationShortcutDesktop" Guid="*">
+                    <Shortcut Id="ApplicationDesktopShortcut" Name="{{product_name}}" Description="Runs {{product_name}}" Target="[!Path]" WorkingDirectory="INSTALLDIR" />
+                    <RemoveFolder Id="DesktopFolder" On="uninstall" />
+                    <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Desktop Shortcut" Type="integer" Value="1" KeyPath="yes" />
+                </Component>
+            </Directory>
+            <Directory Id="$(var.PlatformProgramFilesFolder)" Name="PFiles">
+                <Directory Id="MikanseiLaboratoryDir" Name="MikanseiLaboratory">
+                    <Directory Id="INSTALLDIR" Name="{{product_name}}"/>
+                </Directory>
+            </Directory>
+            <Directory Id="ProgramMenuFolder">
+                <Directory Id="ApplicationProgramsFolder" Name="{{product_name}}"/>
+            </Directory>
+        </Directory>
+
+        <DirectoryRef Id="INSTALLDIR">
+            <Component Id="RegistryEntries" Guid="*">
+                <RegistryKey Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}">
+                    <RegistryValue Name="InstallDir" Type="string" Value="[INSTALLDIR]" KeyPath="yes" />
+                </RegistryKey>
+                <!-- Change the Root to HKCU for perUser installations -->
+                {{#each deep_link_protocols as |protocol| ~}}
+                <RegistryKey Root="HKLM" Key="Software\Classes\\{{protocol}}">
+                    <RegistryValue Type="string" Name="URL Protocol" Value=""/>
+                    <RegistryValue Type="string" Value="URL:{{bundle_id}} protocol"/>
+                    <RegistryKey Key="DefaultIcon">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot;,0" />
+                    </RegistryKey>
+                    <RegistryKey Key="shell\open\command">
+                        <RegistryValue Type="string" Value="&quot;[!Path]&quot; &quot;%1&quot;" />
+                    </RegistryKey>
+                </RegistryKey>
+                {{/each~}}
+            </Component>
+            <Component Id="Path" Guid="{{path_component_guid}}" Win64="$(var.Win64)">
+                <File Id="Path" Source="{{main_binary_path}}" KeyPath="yes" Checksum="yes"/>
+                {{#each file_associations as |association| ~}}
+                {{#each association.ext as |ext| ~}}
+                <ProgId Id="{{../../product_name}}.{{ext}}" Advertise="yes" Description="{{association.description}}">
+                    <Extension Id="{{ext}}" Advertise="yes">
+                        <Verb Id="open" Command="Open with {{../../product_name}}" Argument="&quot;%1&quot;" />
+                    </Extension>
+                </ProgId>
+                {{/each~}}
+                {{/each~}}
+            </Component>
+            {{#each binaries as |bin| ~}}
+            <Component Id="{{ bin.id }}" Guid="{{bin.guid}}" Win64="$(var.Win64)">
+                <File Id="Bin_{{ bin.id }}" Source="{{bin.path}}" KeyPath="yes"/>
+            </Component>
+            {{/each~}}
+            {{#if enable_elevated_update_task}}
+            <Component Id="UpdateTask" Guid="C492327D-9720-4CD5-8DB8-F09082AF44BE" Win64="$(var.Win64)">
+                <File Id="UpdateTask" Source="update.xml" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskInstaller" Guid="011F25ED-9BE3-50A7-9E9B-3519ED2B9932" Win64="$(var.Win64)">
+                <File Id="UpdateTaskInstaller" Source="install-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            <Component Id="UpdateTaskUninstaller" Guid="D4F6CC3F-32DC-5FD0-95E8-782FFD7BBCE1" Win64="$(var.Win64)">
+                <File Id="UpdateTaskUninstaller" Source="uninstall-task.ps1" KeyPath="yes" Checksum="yes"/>
+            </Component>
+            {{/if}}
+            {{resources}}
+            <Component Id="CMP_UninstallShortcut" Guid="*">
+
+                <Shortcut Id="UninstallShortcut"
+						  Name="Uninstall {{product_name}}"
+						  Description="Uninstalls {{product_name}}"
+						  Target="[System64Folder]msiexec.exe"
+						  Arguments="/x [ProductCode]" />
+
+				<RemoveFolder Id="INSTALLDIR"
+							  On="uninstall" />
+
+				<RegistryValue Root="HKCU"
+							   Key="Software\\{{manufacturer}}\\{{product_name}}"
+							   Name="Uninstaller Shortcut"
+							   Type="integer"
+							   Value="1"
+							   KeyPath="yes" />
+            </Component>
+        </DirectoryRef>
+
+        <DirectoryRef Id="ApplicationProgramsFolder">
+            <Component Id="ApplicationShortcut" Guid="*">
+                <Shortcut Id="ApplicationStartMenuShortcut"
+                    Name="{{product_name}}"
+                    Description="Runs {{product_name}}"
+                    Target="[!Path]"
+                    Icon="ProductIcon"
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}"/>
+                </Shortcut>
+                <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
+                <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
+           </Component>
+        </DirectoryRef>
+
+        {{#each merge_modules as |msm| ~}}
+        <DirectoryRef Id="TARGETDIR">
+            <Merge Id="{{ msm.name }}" SourceFile="{{ msm.path }}" DiskId="1" Language="!(loc.TauriLanguage)" />
+        </DirectoryRef>
+
+        <Feature Id="{{ msm.name }}" Title="{{ msm.name }}" AllowAdvertise="no" Display="hidden" Level="1">
+            <MergeRef Id="{{ msm.name }}"/>
+        </Feature>
+        {{/each~}}
+
+        <Feature
+                Id="MainProgram"
+                Title="Application"
+                Description="!(loc.InstallAppFeature)"
+                Level="1"
+                ConfigurableDirectory="INSTALLDIR"
+                AllowAdvertise="no"
+                Display="expand"
+                Absent="disallow">
+
+            <ComponentRef Id="RegistryEntries"/>
+
+            {{#each resource_file_ids as |resource_file_id| ~}}
+                <ComponentRef Id="{{ resource_file_id }}"/>
+            {{/each~}}
+
+            {{#if enable_elevated_update_task}}
+                <ComponentRef Id="UpdateTask" />
+                <ComponentRef Id="UpdateTaskInstaller" />
+                <ComponentRef Id="UpdateTaskUninstaller" />
+            {{/if}}
+
+            <Feature Id="ShortcutsFeature"
+                Title="Shortcuts"
+                Level="1">
+                <ComponentRef Id="Path"/>
+                <ComponentRef Id="CMP_UninstallShortcut" />
+                <ComponentRef Id="ApplicationShortcut" />
+                <ComponentRef Id="ApplicationShortcutDesktop" />
+            </Feature>
+
+            <Feature
+                Id="Environment"
+                Title="PATH Environment Variable"
+                Description="!(loc.PathEnvVarFeature)"
+                Level="1"
+                Absent="allow">
+            <ComponentRef Id="Path"/>
+            {{#each binaries as |bin| ~}}
+            <ComponentRef Id="{{ bin.id }}"/>
+            {{/each~}}
+            </Feature>
+        </Feature>
+
+        <Feature Id="External" AllowAdvertise="no" Absent="disallow">
+            {{#each component_group_refs as |id| ~}}
+            <ComponentGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each component_refs as |id| ~}}
+            <ComponentRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_group_refs as |id| ~}}
+            <FeatureGroupRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each feature_refs as |id| ~}}
+            <FeatureRef Id="{{ id }}"/>
+            {{/each~}}
+            {{#each merge_refs as |id| ~}}
+            <MergeRef Id="{{ id }}"/>
+            {{/each~}}
+        </Feature>
+
+        {{#if install_webview}}
+        <!-- WebView2 -->
+        <Property Id="INSTALLED_WEBVIEW2_VERSION">
+            <RegistrySearch Id="Webview2VersionSystemx64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionSystemx86" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw" />
+            <RegistrySearch Id="Webview2VersionUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}" Name="pv" Type="raw"/>
+        </Property>
+
+        {{#if download_bootstrapper}}
+        <!-- Download webview bootstrapper mode -->
+        <CustomAction Id='DownloadAndInvokeBootstrapper' Directory="INSTALLDIR" Execute="deferred" ExeCommand='powershell.exe -NoProfile -windowstyle hidden try [\{] [\[]Net.ServicePointManager[\]]::SecurityProtocol = [\[]Net.SecurityProtocolType[\]]::Tls12 [\}] catch [\{][\}]; Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" ; Start-Process -FilePath "$env:TEMP\MicrosoftEdgeWebview2Setup.exe" -ArgumentList ({{webview_installer_args}} &apos;/install&apos;) -Wait' Return='check'/>
+        <InstallExecuteSequence>
+            <Custom Action='DownloadAndInvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_bootstrapper_path}}
+        <!-- Embedded webview bootstrapper mode -->
+        <Binary Id="MicrosoftEdgeWebview2Setup.exe" SourceFile="{{webview2_bootstrapper_path}}"/>
+        <CustomAction Id='InvokeBootstrapper' BinaryKey='MicrosoftEdgeWebview2Setup.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeBootstrapper' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if webview2_installer_path}}
+        <!-- Embedded offline installer -->
+        <Binary Id="MicrosoftEdgeWebView2RuntimeInstaller.exe" SourceFile="{{webview2_installer_path}}"/>
+        <CustomAction Id='InvokeStandalone' BinaryKey='MicrosoftEdgeWebView2RuntimeInstaller.exe' Execute="deferred" ExeCommand='{{webview_installer_args}} /install' Return='check' />
+        <InstallExecuteSequence>
+            <Custom Action='InvokeStandalone' Before='InstallFinalize'>
+                <![CDATA[NOT(REMOVE OR INSTALLED_WEBVIEW2_VERSION)]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{#if minimum_webview2_version}}
+        <!-- Update WebView2 if minimum version requirement not met -->
+        <Property Id="MINIMUM_WEBVIEW2_VERSION" Value="{{minimum_webview2_version}}" />
+        <Property Id="EDGEUPDATE_PATH">
+            <RegistrySearch Id="EdgeUpdateLocalMachine64" Root="HKLM" Key="SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate" Name="path" Type="raw" />
+            <RegistrySearch Id="EdgeUpdateLocalMachine32" Root="HKLM" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+            <RegistrySearch Id="EdgeUpdateCurrentUser" Root="HKCU" Key="SOFTWARE\Microsoft\EdgeUpdate" Name="path" Type="raw"/>
+        </Property>
+        <!-- Chromium updater docs: https://source.chromium.org/chromium/chromium/src/+/main:docs/updater/user_manual.md -->
+        <!-- Modified from "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft EdgeWebView\ModifyPath" -->
+        <CustomAction Id="UpdateWebView2ViaEdgeUpdate" Execute="deferred" Property="EDGEUPDATE_PATH" Return="check" Impersonate="no" ExeCommand="/install appguid={F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}&amp;needsadmin=true" />
+        <InstallExecuteSequence>
+            <Custom Action='UpdateWebView2ViaEdgeUpdate' Before='InstallFinalize'>
+                <![CDATA[
+                  NOT REMOVE
+                  AND INSTALLED_WEBVIEW2_VERSION
+                  AND (INSTALLED_WEBVIEW2_VERSION < MINIMUM_WEBVIEW2_VERSION)
+                ]]>
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        {{/if}}
+
+        {{#if enable_elevated_update_task}}
+        <!-- Install an elevated update task within Windows Task Scheduler -->
+        <CustomAction
+            Id="CreateUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            Execute="commit"
+            Impersonate="yes"
+            ExeCommand="powershell.exe -WindowStyle hidden .\install-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action='CreateUpdateTask' Before='InstallFinalize'>
+                NOT(REMOVE)
+            </Custom>
+        </InstallExecuteSequence>
+        <!-- Remove elevated update task during uninstall -->
+        <CustomAction
+            Id="DeleteUpdateTask"
+            Return="check"
+            Directory="INSTALLDIR"
+            ExeCommand="powershell.exe -WindowStyle hidden .\uninstall-task.ps1" />
+        <InstallExecuteSequence>
+            <Custom Action="DeleteUpdateTask" Before='InstallFinalize'>
+                (REMOVE = "ALL") AND NOT UPGRADINGPRODUCTCODE
+            </Custom>
+        </InstallExecuteSequence>
+        {{/if}}
+
+        <InstallExecuteSequence>
+          <Custom Action="LaunchApplication" After="InstallFinalize">AUTOLAUNCHAPP AND NOT Installed</Custom>
+        </InstallExecuteSequence>
+
+        <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLDIR]" After="CostFinalize"/>
+    </Product>
+</Wix>

--- a/apps/launcher/src/main.ts
+++ b/apps/launcher/src/main.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
-const DOCS_URL = "https://github.com/MikanseiLaboratory/omt-tools#docs--guides";
+const DOCS_URL = "https://github.com/MikanseiLaboratory/omt-tools#readme";
 
 type ToolCard = {
   id: string;

--- a/apps/launcher/src/main.ts
+++ b/apps/launcher/src/main.ts
@@ -1,5 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { openUrl } from "@tauri-apps/plugin-opener";
+
+const DOCS_URL = "https://github.com/MikanseiLaboratory/omt-tools#docs--guides";
 
 type ToolCard = {
   id: string;
@@ -273,12 +276,12 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   $("settings-btn").addEventListener("click", () => setSettingsOpen(!settingsOpen));
   $("settings-backdrop").addEventListener("click", () => setSettingsOpen(false));
-  $("docs-btn").addEventListener("click", () => {
-    window.open(
-      "https://github.com/MikanseiLaboratory/omt-tools#readme",
-      "_blank",
-      "noopener,noreferrer",
-    );
+  $("docs-btn").addEventListener("click", async () => {
+    try {
+      await openUrl(DOCS_URL);
+    } catch (err) {
+      showToast(String(err));
+    }
   });
 
   $("save-settings").addEventListener("click", async () => {

--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -985,6 +985,7 @@ impl MonitorApp {
                 ui.add_space(10.0);
 
                 egui::ScrollArea::vertical()
+                    .id_salt("monitor_sources")
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         let none_sel = self.selected.is_none();
@@ -1106,138 +1107,140 @@ impl MonitorApp {
             .inner_margin(egui::Margin::symmetric(16, 14))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
-                egui::ScrollArea::vertical().show(ui, |ui| {
-                    ui.spacing_mut().item_spacing.y = 10.0;
-                    let source_fps = if self.fps_d > 0 {
-                        self.fps_n as f32 / self.fps_d as f32
-                    } else {
-                        0.0
-                    };
-                    let buffer_label = format_buffer_stats(
-                        self.language,
-                        &self.settings.buffer,
-                        self.video_buffer_delay_ms,
-                        self.audio_buffer_delay_ms,
-                        self.buffer_fps().0,
-                        self.buffer_fps().1,
-                    );
+                egui::ScrollArea::vertical()
+                    .id_salt("monitor_stats")
+                    .show(ui, |ui| {
+                        ui.spacing_mut().item_spacing.y = 10.0;
+                        let source_fps = if self.fps_d > 0 {
+                            self.fps_n as f32 / self.fps_d as f32
+                        } else {
+                            0.0
+                        };
+                        let buffer_label = format_buffer_stats(
+                            self.language,
+                            &self.settings.buffer,
+                            self.video_buffer_delay_ms,
+                            self.audio_buffer_delay_ms,
+                            self.buffer_fps().0,
+                            self.buffer_fps().1,
+                        );
 
-                    ui.label(
-                        RichText::new(t(self.language, "monitor.stats"))
-                            .strong()
-                            .color(chrome.text),
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Display FPS",
-                        format!("{:.1}", self.display_fps),
-                    );
-                    stat_row(ui, chrome, "Source FPS", format!("{source_fps:.2}"));
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Presented",
-                        format!("{}", self.frames_presented),
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Source dropped",
-                        format!("{}", self.source_dropped),
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Render skipped",
-                        format!("{}", self.frames_render_skipped),
-                    );
-                    stat_row(ui, chrome, "Net dropped", format!("{}", self.net_dropped));
-                    stat_row(ui, chrome, "Decoded", format!("{}", self.frames_decoded));
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Decode ms",
-                        format!(
-                            "{:.2} (peak {:.2})",
-                            self.decode_ms_avg, self.decode_ms_peak
-                        ),
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Wire queue",
-                        format!("{}", self.wire_queue_depth),
-                    );
-                    stat_row(ui, chrome, "Reconnects", format!("{}", self.reconnects));
-                    stat_row(ui, chrome, "Session", format!("{:?}", self.session_state));
-
-                    ui.add_space(8.0);
-                    ui.label(
-                        RichText::new(t(self.language, "monitor.audio"))
-                            .strong()
-                            .color(chrome.text),
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Audio packets",
-                        format!("{}", self.audio_frames),
-                    );
-                    stat_row(ui, chrome, "L", format_dbfs(self.audio_levels.peak_l));
-                    stat_row(ui, chrome, "R", format_dbfs(self.audio_levels.peak_r));
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Format",
-                        if self.audio_levels.sample_rate > 0 {
+                        ui.label(
+                            RichText::new(t(self.language, "monitor.stats"))
+                                .strong()
+                                .color(chrome.text),
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Display FPS",
+                            format!("{:.1}", self.display_fps),
+                        );
+                        stat_row(ui, chrome, "Source FPS", format!("{source_fps:.2}"));
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Presented",
+                            format!("{}", self.frames_presented),
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Source dropped",
+                            format!("{}", self.source_dropped),
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Render skipped",
+                            format!("{}", self.frames_render_skipped),
+                        );
+                        stat_row(ui, chrome, "Net dropped", format!("{}", self.net_dropped));
+                        stat_row(ui, chrome, "Decoded", format!("{}", self.frames_decoded));
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Decode ms",
                             format!(
-                                "{} Hz / {} ch",
-                                self.audio_levels.sample_rate, self.audio_levels.channels
-                            )
-                        } else {
-                            "-".into()
-                        },
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        t(self.language, "monitor.av_buffer"),
-                        buffer_label,
-                    );
+                                "{:.2} (peak {:.2})",
+                                self.decode_ms_avg, self.decode_ms_peak
+                            ),
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Wire queue",
+                            format!("{}", self.wire_queue_depth),
+                        );
+                        stat_row(ui, chrome, "Reconnects", format!("{}", self.reconnects));
+                        stat_row(ui, chrome, "Session", format!("{:?}", self.session_state));
 
-                    ui.add_space(8.0);
-                    ui.label(
-                        RichText::new(t(self.language, "monitor.source_info"))
-                            .strong()
-                            .color(chrome.text),
-                    );
-                    stat_row(
-                        ui,
-                        chrome,
-                        "Resolution",
-                        if self.frame_w > 0 {
-                            format!("{}×{}", self.frame_w, self.frame_h)
-                        } else {
-                            "-".into()
-                        },
-                    );
-                    stat_row(ui, chrome, "Bitrate", format_bitrate(self.bitrate_bps));
-                    stat_row(ui, chrome, "Bytes RX", format_bytes(self.bytes_received));
-                    stat_row(
-                        ui,
-                        chrome,
-                        "URL",
-                        self.selected.clone().unwrap_or_else(|| "-".into()),
-                    );
-                    ui.add_space(8.0);
-                    stat_row(
-                        ui,
-                        chrome,
-                        t(self.language, "simd"),
-                        self.simd_summary.clone(),
-                    );
-                });
+                        ui.add_space(8.0);
+                        ui.label(
+                            RichText::new(t(self.language, "monitor.audio"))
+                                .strong()
+                                .color(chrome.text),
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Audio packets",
+                            format!("{}", self.audio_frames),
+                        );
+                        stat_row(ui, chrome, "L", format_dbfs(self.audio_levels.peak_l));
+                        stat_row(ui, chrome, "R", format_dbfs(self.audio_levels.peak_r));
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Format",
+                            if self.audio_levels.sample_rate > 0 {
+                                format!(
+                                    "{} Hz / {} ch",
+                                    self.audio_levels.sample_rate, self.audio_levels.channels
+                                )
+                            } else {
+                                "-".into()
+                            },
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            t(self.language, "monitor.av_buffer"),
+                            buffer_label,
+                        );
+
+                        ui.add_space(8.0);
+                        ui.label(
+                            RichText::new(t(self.language, "monitor.source_info"))
+                                .strong()
+                                .color(chrome.text),
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
+                            "Resolution",
+                            if self.frame_w > 0 {
+                                format!("{}×{}", self.frame_w, self.frame_h)
+                            } else {
+                                "-".into()
+                            },
+                        );
+                        stat_row(ui, chrome, "Bitrate", format_bitrate(self.bitrate_bps));
+                        stat_row(ui, chrome, "Bytes RX", format_bytes(self.bytes_received));
+                        stat_row(
+                            ui,
+                            chrome,
+                            "URL",
+                            self.selected.clone().unwrap_or_else(|| "-".into()),
+                        );
+                        ui.add_space(8.0);
+                        stat_row(
+                            ui,
+                            chrome,
+                            t(self.language, "simd"),
+                            self.simd_summary.clone(),
+                        );
+                    });
             });
     }
 
@@ -1264,6 +1267,7 @@ impl MonitorApp {
                 ui.separator();
                 ui.add_space(8.0);
                 egui::ScrollArea::vertical()
+                    .id_salt("monitor_log")
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         ui.set_min_width(ui.available_width());

--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -936,9 +936,11 @@ impl MonitorApp {
                         self.open_preferences();
                     }
                     ui.label(
-                        RichText::new("wheel = zoom · middle-drag = pan · F11 / double-click = fullscreen")
-                            .small()
-                            .color(chrome.text_muted),
+                        RichText::new(
+                            "wheel = zoom · middle-drag = pan · F11 / double-click = fullscreen",
+                        )
+                        .small()
+                        .color(chrome.text_muted),
                     );
                 });
             });

--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -31,6 +31,9 @@ const ZOOM_MAX: f32 = 8.0;
 const SIDEBAR_W: f32 = 280.0;
 const STATS_W: f32 = 280.0;
 const LOG_H: f32 = 180.0;
+/// Outer inset + gap between chrome panels (sidebar / preview / stats / log).
+const LAYOUT_GAP: f32 = 10.0;
+const TOOLBAR_H: f32 = 44.0;
 const ACTION_SAFE_FRAC: f32 = 0.93;
 const TITLE_SAFE_FRAC: f32 = 0.90;
 
@@ -822,27 +825,27 @@ impl MonitorApp {
         egui::CentralPanel::default()
             .frame(egui::Frame::NONE.fill(chrome.bg))
             .show(ui, |ui| {
-                let total = ui.available_rect_before_wrap();
+                let gap = LAYOUT_GAP;
+                let total = ui.available_rect_before_wrap().shrink(gap);
                 let log_h = LOG_H.min(total.height() * 0.35);
-                let top_h = (total.height() - log_h).max(100.0);
+                let top_h = (total.height() - log_h - gap).max(100.0);
 
                 let top = Rect::from_min_size(total.min, Vec2::new(total.width(), top_h));
                 let bottom = Rect::from_min_size(
-                    Pos2::new(total.min.x, total.min.y + top_h),
+                    Pos2::new(total.min.x, total.min.y + top_h + gap),
                     Vec2::new(total.width(), log_h),
                 );
 
                 let sidebar = Rect::from_min_size(top.min, Vec2::new(SIDEBAR_W, top.height()));
                 let stats = Rect::from_min_max(Pos2::new(top.max.x - STATS_W, top.min.y), top.max);
                 let preview_col = Rect::from_min_max(
-                    Pos2::new(sidebar.max.x, top.min.y),
-                    Pos2::new(stats.min.x, top.max.y),
+                    Pos2::new(sidebar.max.x + gap, top.min.y),
+                    Pos2::new(stats.min.x - gap, top.max.y),
                 );
-                let toolbar_h = 40.0;
                 let toolbar =
-                    Rect::from_min_size(preview_col.min, Vec2::new(preview_col.width(), toolbar_h));
+                    Rect::from_min_size(preview_col.min, Vec2::new(preview_col.width(), TOOLBAR_H));
                 let picture = Rect::from_min_max(
-                    Pos2::new(preview_col.min.x, preview_col.min.y + toolbar_h),
+                    Pos2::new(preview_col.min.x, preview_col.min.y + TOOLBAR_H + gap),
                     preview_col.max,
                 );
 
@@ -918,7 +921,8 @@ impl MonitorApp {
         egui::Frame::NONE
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
-            .inner_margin(egui::Margin::symmetric(12, 8))
+            .corner_radius(6.0)
+            .inner_margin(egui::Margin::symmetric(14, 10))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.horizontal(|ui| {
@@ -950,29 +954,30 @@ impl MonitorApp {
         egui::Frame::NONE
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
-            .inner_margin(0.0)
+            .corner_radius(6.0)
+            .inner_margin(egui::Margin::symmetric(10, 10))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.horizontal(|ui| {
-                    ui.add_space(12.0);
                     ui.label(
                         RichText::new(t(self.language, "monitor.sources"))
                             .strong()
                             .color(chrome.text),
                     );
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.add_space(8.0);
                         if chip(ui, chrome, t(self.language, "monitor.refresh"), false) {
                             self.request_refresh(false);
                         }
                     });
                 });
+                ui.add_space(6.0);
                 ui.separator();
+                ui.add_space(4.0);
 
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                        ui.add_space(6.0);
+                        ui.add_space(4.0);
                         ui.indent("source-list", |ui| {
                             let none_sel = self.selected.is_none();
                             if source_row(
@@ -1049,23 +1054,21 @@ impl MonitorApp {
                     });
 
                 ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
-                    ui.add_space(8.0);
-                    ui.horizontal(|ui| {
-                        ui.add_space(12.0);
-                        if ui
-                            .add(
-                                egui::Button::new(
-                                    RichText::new(t(self.language, "monitor.preferences"))
-                                        .color(chrome.text),
-                                )
-                                .fill(chrome.surface)
-                                .min_size(Vec2::new(ui.available_width() - 24.0, 32.0)),
+                    ui.add_space(10.0);
+                    if ui
+                        .add(
+                            egui::Button::new(
+                                RichText::new(t(self.language, "monitor.preferences"))
+                                    .color(chrome.text),
                             )
-                            .clicked()
-                        {
-                            self.open_preferences();
-                        }
-                    });
+                            .fill(chrome.surface)
+                            .min_size(Vec2::new(ui.available_width(), 34.0)),
+                        )
+                        .clicked()
+                    {
+                        self.open_preferences();
+                    }
+                    ui.add_space(6.0);
                     ui.separator();
                 });
             });
@@ -1097,7 +1100,8 @@ impl MonitorApp {
         egui::Frame::NONE
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
-            .inner_margin(12.0)
+            .corner_radius(6.0)
+            .inner_margin(egui::Margin::symmetric(14, 12))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 egui::ScrollArea::vertical().show(ui, |ui| {
@@ -1238,11 +1242,11 @@ impl MonitorApp {
         egui::Frame::NONE
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
-            .inner_margin(0.0)
+            .corner_radius(6.0)
+            .inner_margin(egui::Margin::symmetric(12, 10))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.horizontal(|ui| {
-                    ui.add_space(12.0);
                     ui.label(
                         RichText::new(t(self.language, "monitor.log"))
                             .strong()
@@ -1252,7 +1256,9 @@ impl MonitorApp {
                         self.log_lines.clear();
                     }
                 });
+                ui.add_space(4.0);
                 ui.separator();
+                ui.add_space(4.0);
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
@@ -1332,7 +1338,7 @@ fn source_row(ui: &mut Ui, chrome: UiChrome, title: &str, subtitle: &str, select
         });
     });
 
-    ui.add_space(4.0);
+    ui.add_space(6.0);
     inner.response.interact(Sense::click()).clicked()
 }
 

--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -690,7 +690,7 @@ impl MonitorApp {
             PrefsAction::EnterFullscreen => self.enter_fullscreen(ctx),
             PrefsAction::OpenHelp => {
                 ctx.open_url(egui::OpenUrl::new_tab(
-                    "https://github.com/MikanseiLaboratory/omt-tools",
+                    "https://github.com/MikanseiLaboratory/omt-tools#docs--guides",
                 ));
             }
             PrefsAction::OpenLicense => {
@@ -727,12 +727,19 @@ impl eframe::App for MonitorApp {
         self.apply_theme_if_needed(&ctx);
         let got_frame = self.on_tick(&ctx);
 
-        // Escape handling
+        // Escape / F11 fullscreen handling
         if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
             if self.preferences_open {
                 self.preferences_open = false;
             } else if self.fullscreen {
                 self.exit_fullscreen(&ctx);
+            }
+        }
+        if ctx.input(|i| i.key_pressed(egui::Key::F11)) {
+            if self.fullscreen {
+                self.exit_fullscreen(&ctx);
+            } else {
+                self.enter_fullscreen(&ctx);
             }
         }
 
@@ -865,6 +872,9 @@ impl MonitorApp {
         self.preview_h = picture.height();
 
         let resp = ui.interact(picture, ui.id().with("preview"), Sense::click_and_drag());
+        if resp.double_clicked() {
+            self.enter_fullscreen(ui.ctx());
+        }
         if resp.hovered() {
             let scroll = ui.input(|i| i.smooth_scroll_delta.y);
             if scroll.abs() > f32::EPSILON {
@@ -919,11 +929,14 @@ impl MonitorApp {
                     if chip(ui, chrome, t(self.language, "monitor.zoom_reset"), false) {
                         self.zoom_reset();
                     }
+                    if chip(ui, chrome, t(self.language, "monitor.fullscreen"), false) {
+                        self.enter_fullscreen(ui.ctx());
+                    }
                     if chip(ui, chrome, t(self.language, "monitor.preferences"), false) {
                         self.open_preferences();
                     }
                     ui.label(
-                        RichText::new("wheel = zoom · middle-drag = pan")
+                        RichText::new("wheel = zoom · middle-drag = pan · F11 / double-click = fullscreen")
                             .small()
                             .color(chrome.text_muted),
                     );

--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -690,7 +690,7 @@ impl MonitorApp {
             PrefsAction::EnterFullscreen => self.enter_fullscreen(ctx),
             PrefsAction::OpenHelp => {
                 ctx.open_url(egui::OpenUrl::new_tab(
-                    "https://github.com/MikanseiLaboratory/omt-tools#docs--guides",
+                    "https://github.com/MikanseiLaboratory/omt-tools#readme",
                 ));
             }
             PrefsAction::OpenLicense => {

--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -28,12 +28,12 @@ type DiscoveryResult = Result<Vec<DiscoveredSource>, String>;
 
 const ZOOM_MIN: f32 = 0.1;
 const ZOOM_MAX: f32 = 8.0;
-const SIDEBAR_W: f32 = 280.0;
+const SIDEBAR_W: f32 = 300.0;
 const STATS_W: f32 = 280.0;
 const LOG_H: f32 = 180.0;
 /// Outer inset + gap between chrome panels (sidebar / preview / stats / log).
-const LAYOUT_GAP: f32 = 10.0;
-const TOOLBAR_H: f32 = 44.0;
+const LAYOUT_GAP: f32 = 14.0;
+const TOOLBAR_H: f32 = 48.0;
 const ACTION_SAFE_FRAC: f32 = 0.93;
 const TITLE_SAFE_FRAC: f32 = 0.90;
 
@@ -869,12 +869,22 @@ impl MonitorApp {
     }
 
     fn paint_picture_layer(&mut self, ui: &mut Ui, chrome: UiChrome, picture: Rect) {
-        // Opaque letterbox behind the picture (still under chrome panels).
-        ui.painter().rect_filled(picture, 0.0, chrome.bg);
-        self.preview_w = picture.width();
-        self.preview_h = picture.height();
+        // Card chrome so the gap against neighboring panels is visible.
+        let radius = 6.0;
+        ui.painter().rect_filled(picture, radius, chrome.panel);
+        ui.painter().rect_stroke(
+            picture,
+            radius,
+            egui::Stroke::new(1.0, chrome.border),
+            egui::StrokeKind::Inside,
+        );
+        // Inset the interactive / video region so content isn't flush to the card edge.
+        let inset = 8.0;
+        let content = picture.shrink(inset);
+        self.preview_w = content.width();
+        self.preview_h = content.height();
 
-        let resp = ui.interact(picture, ui.id().with("preview"), Sense::click_and_drag());
+        let resp = ui.interact(content, ui.id().with("preview"), Sense::click_and_drag());
         if resp.double_clicked() {
             self.enter_fullscreen(ui.ctx());
         }
@@ -902,13 +912,12 @@ impl MonitorApp {
         let has_frame = self.texture.is_some() && self.frame_w > 0 && self.frame_h > 0;
         if has_frame {
             let (dw, dh) = self.display_size();
-            let origin = picture.min + Vec2::new(self.pan_x, self.pan_y);
+            let origin = content.min + Vec2::new(self.pan_x, self.pan_y);
             let video_rect = Rect::from_min_size(origin, Vec2::new(dw, dh));
-            self.paint_video_stack(ui, chrome, video_rect, picture);
+            self.paint_video_stack(ui, chrome, video_rect, content);
         } else {
-            // Centered in the full picture viewport (not a 1×1 pan origin).
             ui.painter().text(
-                picture.center(),
+                content.center(),
                 egui::Align2::CENTER_CENTER,
                 t(self.language, "monitor.waiting"),
                 egui::FontId::proportional(16.0),
@@ -922,10 +931,11 @@ impl MonitorApp {
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
             .corner_radius(6.0)
-            .inner_margin(egui::Margin::symmetric(14, 10))
+            .inner_margin(egui::Margin::symmetric(16, 12))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.horizontal(|ui| {
+                    ui.spacing_mut().item_spacing.x = 12.0;
                     ui.label(RichText::new(&self.stall_text).color(chrome.text));
                     ui.label(
                         RichText::new(format!("{:.0}%", self.zoom * 100.0)).color(chrome.text),
@@ -955,7 +965,7 @@ impl MonitorApp {
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
             .corner_radius(6.0)
-            .inner_margin(egui::Margin::symmetric(10, 10))
+            .inner_margin(egui::Margin::symmetric(14, 14))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.horizontal(|ui| {
@@ -970,91 +980,81 @@ impl MonitorApp {
                         }
                     });
                 });
-                ui.add_space(6.0);
+                ui.add_space(10.0);
                 ui.separator();
-                ui.add_space(4.0);
+                ui.add_space(10.0);
 
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
-                        ui.add_space(4.0);
-                        ui.indent("source-list", |ui| {
-                            let none_sel = self.selected.is_none();
-                            if source_row(
-                                ui,
-                                chrome,
-                                t(self.language, "monitor.none"),
-                                "",
-                                none_sel,
-                            ) {
-                                self.disconnect_source();
-                            }
+                        let none_sel = self.selected.is_none();
+                        if source_row(ui, chrome, t(self.language, "monitor.none"), "", none_sel) {
+                            self.disconnect_source();
+                        }
 
-                            if self.discovered.is_empty() {
-                                ui.add_space(8.0);
-                                ui.label(
-                                    RichText::new(t(self.language, "monitor.no_sources"))
-                                        .color(chrome.text_muted)
-                                        .small(),
-                                );
-                            } else {
-                                let mut hosts: Vec<(String, Vec<DiscoveredSource>)> = Vec::new();
-                                for s in &self.discovered {
-                                    if let Some((_, list)) =
-                                        hosts.iter_mut().find(|(h, _)| h == &s.host)
-                                    {
-                                        list.push(s.clone());
-                                    } else {
-                                        hosts.push((s.host.clone(), vec![s.clone()]));
-                                    }
+                        if self.discovered.is_empty() {
+                            ui.add_space(12.0);
+                            ui.label(
+                                RichText::new(t(self.language, "monitor.no_sources"))
+                                    .color(chrome.text_muted)
+                                    .small(),
+                            );
+                        } else {
+                            let mut hosts: Vec<(String, Vec<DiscoveredSource>)> = Vec::new();
+                            for s in &self.discovered {
+                                if let Some((_, list)) =
+                                    hosts.iter_mut().find(|(h, _)| h == &s.host)
+                                {
+                                    list.push(s.clone());
+                                } else {
+                                    hosts.push((s.host.clone(), vec![s.clone()]));
                                 }
-                                for (host, sources) in hosts {
-                                    ui.add_space(10.0);
-                                    ui.horizontal(|ui| {
-                                        ui.label(
-                                            RichText::new(host.to_uppercase())
-                                                .size(11.0)
-                                                .strong()
-                                                .color(chrome.text_muted),
-                                        );
-                                        ui.with_layout(
-                                            egui::Layout::right_to_left(egui::Align::Center),
-                                            |ui| {
-                                                ui.label(
-                                                    RichText::new(format!("{}", sources.len()))
-                                                        .size(11.0)
-                                                        .color(chrome.text_muted),
-                                                );
-                                            },
-                                        );
-                                    });
-                                    ui.add_space(2.0);
-                                    for s in sources {
-                                        let label = if s.source.is_empty() {
-                                            s.name.clone()
-                                        } else {
-                                            s.source.clone()
-                                        };
-                                        let selected =
-                                            self.selected.as_deref() == Some(s.url.as_str());
-                                        if source_row(
-                                            ui,
-                                            chrome,
-                                            &label,
-                                            &format!(":{}", s.port),
-                                            selected,
-                                        ) {
-                                            self.select(s.url.clone(), s.addresses.clone());
-                                        }
+                            }
+                            for (host, sources) in hosts {
+                                ui.add_space(16.0);
+                                ui.horizontal(|ui| {
+                                    ui.label(
+                                        RichText::new(host.to_uppercase())
+                                            .size(11.0)
+                                            .strong()
+                                            .color(chrome.text_muted),
+                                    );
+                                    ui.with_layout(
+                                        egui::Layout::right_to_left(egui::Align::Center),
+                                        |ui| {
+                                            ui.label(
+                                                RichText::new(format!("{}", sources.len()))
+                                                    .size(11.0)
+                                                    .color(chrome.text_muted),
+                                            );
+                                        },
+                                    );
+                                });
+                                ui.add_space(8.0);
+                                for s in sources {
+                                    let label = if s.source.is_empty() {
+                                        s.name.clone()
+                                    } else {
+                                        s.source.clone()
+                                    };
+                                    let selected = self.selected.as_deref() == Some(s.url.as_str());
+                                    if source_row(
+                                        ui,
+                                        chrome,
+                                        &label,
+                                        &format!(":{}", s.port),
+                                        selected,
+                                    ) {
+                                        self.select(s.url.clone(), s.addresses.clone());
                                     }
                                 }
                             }
-                            ui.add_space(8.0);
-                        });
+                        }
+                        ui.add_space(12.0);
                     });
 
                 ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
-                    ui.add_space(10.0);
+                    ui.add_space(12.0);
                     if ui
                         .add(
                             egui::Button::new(
@@ -1062,14 +1062,16 @@ impl MonitorApp {
                                     .color(chrome.text),
                             )
                             .fill(chrome.surface)
-                            .min_size(Vec2::new(ui.available_width(), 34.0)),
+                            .corner_radius(6.0)
+                            .min_size(Vec2::new(ui.available_width(), 36.0)),
                         )
                         .clicked()
                     {
                         self.open_preferences();
                     }
-                    ui.add_space(6.0);
+                    ui.add_space(10.0);
                     ui.separator();
+                    ui.add_space(4.0);
                 });
             });
     }
@@ -1101,10 +1103,11 @@ impl MonitorApp {
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
             .corner_radius(6.0)
-            .inner_margin(egui::Margin::symmetric(14, 12))
+            .inner_margin(egui::Margin::symmetric(16, 14))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 egui::ScrollArea::vertical().show(ui, |ui| {
+                    ui.spacing_mut().item_spacing.y = 10.0;
                     let source_fps = if self.fps_d > 0 {
                         self.fps_n as f32 / self.fps_d as f32
                     } else {
@@ -1243,7 +1246,7 @@ impl MonitorApp {
             .fill(chrome.panel)
             .stroke(egui::Stroke::new(1.0, chrome.border))
             .corner_radius(6.0)
-            .inner_margin(egui::Margin::symmetric(12, 10))
+            .inner_margin(egui::Margin::symmetric(14, 12))
             .show(ui, |ui| {
                 ui.set_min_size(ui.available_size());
                 ui.horizontal(|ui| {
@@ -1252,13 +1255,14 @@ impl MonitorApp {
                             .strong()
                             .color(chrome.text),
                     );
+                    ui.add_space(8.0);
                     if chip(ui, chrome, t(self.language, "monitor.clear_log"), false) {
                         self.log_lines.clear();
                     }
                 });
-                ui.add_space(4.0);
+                ui.add_space(8.0);
                 ui.separator();
-                ui.add_space(4.0);
+                ui.add_space(8.0);
                 egui::ScrollArea::vertical()
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
@@ -1311,14 +1315,14 @@ fn source_row(ui: &mut Ui, chrome: UiChrome, title: &str, subtitle: &str, select
     let frame = egui::Frame::NONE
         .fill(fill)
         .stroke(egui::Stroke::new(1.0, stroke))
-        .corner_radius(6.0)
-        .inner_margin(egui::Margin::symmetric(10, 8));
+        .corner_radius(8.0)
+        .inner_margin(egui::Margin::symmetric(14, 12));
 
     let inner = frame.show(ui, |ui| {
         ui.set_min_width(ui.available_width());
         ui.horizontal(|ui| {
             // Selection dot
-            let (dot_rect, _) = ui.allocate_exact_size(Vec2::splat(8.0), Sense::hover());
+            let (dot_rect, _) = ui.allocate_exact_size(Vec2::splat(10.0), Sense::hover());
             ui.painter().circle_filled(
                 dot_rect.center(),
                 3.5,
@@ -1328,8 +1332,9 @@ fn source_row(ui: &mut Ui, chrome: UiChrome, title: &str, subtitle: &str, select
                     chrome.text_muted
                 },
             );
-            ui.add_space(6.0);
+            ui.add_space(10.0);
             ui.vertical(|ui| {
+                ui.spacing_mut().item_spacing.y = 4.0;
                 ui.label(RichText::new(title).size(13.0).strong().color(title_color));
                 if !subtitle.is_empty() {
                     ui.label(RichText::new(subtitle).size(11.0).color(chrome.text_muted));
@@ -1338,7 +1343,7 @@ fn source_row(ui: &mut Ui, chrome: UiChrome, title: &str, subtitle: &str, select
         });
     });
 
-    ui.add_space(6.0);
+    ui.add_space(10.0);
     inner.response.interact(Sense::click()).clicked()
 }
 

--- a/apps/studio-monitor/src/chrome.rs
+++ b/apps/studio-monitor/src/chrome.rs
@@ -90,8 +90,11 @@ impl UiChrome {
         visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, self.border);
         ctx.set_visuals(visuals);
         // Match Test Patterns: UI chrome text should not be drag-selectable.
+        // Slightly roomier default spacing so panels feel less cramped.
         ctx.all_styles_mut(|style| {
             style.interaction.selectable_labels = false;
+            style.spacing.item_spacing = egui::vec2(10.0, 8.0);
+            style.spacing.window_margin = egui::Margin::same(12);
         });
     }
 }

--- a/apps/studio-monitor/src/chrome.rs
+++ b/apps/studio-monitor/src/chrome.rs
@@ -89,6 +89,10 @@ impl UiChrome {
         visuals.window_stroke = egui::Stroke::new(1.0, self.border);
         visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, self.border);
         ctx.set_visuals(visuals);
+        // Match Test Patterns: UI chrome text should not be drag-selectable.
+        ctx.all_styles_mut(|style| {
+            style.interaction.selectable_labels = false;
+        });
     }
 }
 

--- a/apps/studio-monitor/src/preferences.rs
+++ b/apps/studio-monitor/src/preferences.rs
@@ -121,6 +121,7 @@ pub fn show(
         ui.separator();
 
         egui::ScrollArea::vertical()
+            .id_salt("prefs_body")
             .max_height(ctx.content_rect().height() * 0.75)
             .show(ui, |ui| {
                 ui.add_space(12.0);
@@ -230,6 +231,7 @@ pub fn show(
                         .show(ui, |ui| {
                             ui.set_min_height(100.0);
                             egui::ScrollArea::vertical()
+                                .id_salt("prefs_audio_devices")
                                 .max_height(120.0)
                                 .show(ui, |ui| {
                                     let default_selected = selected_audio.is_none();

--- a/apps/studio-monitor/src/preferences.rs
+++ b/apps/studio-monitor/src/preferences.rs
@@ -94,7 +94,7 @@ pub fn show(
                 .fill(chrome.panel)
                 .stroke(egui::Stroke::new(1.0, chrome.border))
                 .corner_radius(8.0)
-                .inner_margin(egui::Margin::ZERO),
+                .inner_margin(egui::Margin::symmetric(4, 8)),
         );
 
     let response = modal.show(ctx, |ui| {
@@ -103,7 +103,7 @@ pub fn show(
 
         // Header
         ui.horizontal(|ui| {
-            ui.add_space(16.0);
+            ui.add_space(12.0);
             ui.label(
                 RichText::new(t(language, "monitor.preferences"))
                     .strong()
@@ -111,7 +111,7 @@ pub fn show(
                     .color(chrome.text),
             );
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                ui.add_space(8.0);
+                ui.add_space(12.0);
                 if chip_button(ui, chrome, t(language, "back"), false) {
                     action = Some(PrefsAction::Close);
                 }
@@ -123,7 +123,7 @@ pub fn show(
         egui::ScrollArea::vertical()
             .max_height(ctx.content_rect().height() * 0.75)
             .show(ui, |ui| {
-                ui.add_space(8.0);
+                ui.add_space(12.0);
                 ui.indent("prefs-body", |ui| {
                     // —— Language / Theme ——
                     section_title(ui, chrome, t(language, "language"));

--- a/crates/suite-core/src/fonts.rs
+++ b/crates/suite-core/src/fonts.rs
@@ -29,8 +29,10 @@ pub fn load_cjk_font_bytes() -> Option<Vec<u8>> {
     load_cjk_font().map(|(bytes, _)| bytes)
 }
 
-/// Install a simple modern Japanese UI font as the primary proportional face,
-/// with Segoe UI as Latin companion when present.
+/// Install Latin + Japanese UI fonts for egui.
+///
+/// Segoe UI (or platform UI sans) is primary so English stays clean; Japanese
+/// faces are registered as fallbacks for kana/kanji.
 #[cfg(feature = "egui-fonts")]
 pub fn install_egui_cjk_fonts(ctx: &egui::Context) {
     use std::sync::Arc;
@@ -54,17 +56,17 @@ pub fn install_egui_cjk_fonts(ctx: &egui::Context) {
     }
 
     if let Some(proportional) = fonts.families.get_mut(&egui::FontFamily::Proportional) {
-        // JP first so kana/kanji use the business gothic; Latin falls through to Segoe / egui.
-        if fonts.font_data.contains_key("omt_jp") {
-            proportional.insert(0, "omt_jp".into());
-        }
+        // Latin first so English uses Segoe; JP second for kana/kanji fallback.
         if fonts.font_data.contains_key("omt_latin") {
-            let insert_at = if fonts.font_data.contains_key("omt_jp") {
+            proportional.insert(0, "omt_latin".into());
+        }
+        if fonts.font_data.contains_key("omt_jp") {
+            let insert_at = if fonts.font_data.contains_key("omt_latin") {
                 1
             } else {
                 0
             };
-            proportional.insert(insert_at, "omt_latin".into());
+            proportional.insert(insert_at, "omt_jp".into());
         }
     }
     if let Some(monospace) = fonts.families.get_mut(&egui::FontFamily::Monospace)


### PR DESCRIPTION
## Summary
- **#9** Install Windows builds under `MikanseiLaboratory\OMT Tools` via custom NSIS/WiX templates (same layout as vmix-utility)
- **#10** Prefer Segoe UI for Latin glyphs, keep JP as CJK fallback; disable selectable labels in Studio Monitor
- **#11** Expose fullscreen from toolbar, F11, and double-click preview (Esc/click/F11 to exit)
- **#13** Docs & Guides opens README guides via `@tauri-apps/plugin-opener` (window.open was a no-op in the WebView)

## Test plan
- [x] Click launcher **Docs & Guides** and confirm the browser opens the README docs section
- [x] Studio Monitor: English + Japanese labels look correct; text is not drag-selectable
- [x] Studio Monitor: enter fullscreen via toolbar / F11 / double-click; exit via Esc / click / F11
- [x] (Release packaging) Confirm NSIS/MSI default path is `...\MikanseiLaboratory\OMT Tools`

Closes #9
Closes #10
Closes #11
Closes #13