### PR TITLE
Bump vmx-rs and openmediatransport-rs for AVX2/NEON SIMD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2248,7 +2248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5209,7 +5209,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6084,6 +6084,7 @@ dependencies = [
  "cpal",
  "openmediatransport",
  "parking_lot",
+ "suite-core",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6186,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#a8bc036d878c8aad422f3efe7934f5b7b688a62e"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#8fa1408e3cada1c53b1b9d33f1bd297ac94fe077"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -6874,7 +6875,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7420,7 +7421,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7486,7 +7487,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8196,7 +8197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8290,7 +8291,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9039,7 +9040,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9550,7 +9551,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9609,7 +9610,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9927,7 +9928,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs#6cf175070b372b77cd52236aca3b5da18439af85"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs#9980d38c541dea0ad7f9d5eff019f22d189c2c8c"
 dependencies = [
  "rayon",
  "thiserror 2.0.20",
@@ -10594,7 +10595,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Open Media Transport production utilities inspired by NDI Tools.
 | Test Patterns |  Send SMPTE-style patterns + tone over OMT |
 | Screen Capture |  Windows Graphics Capture / ScreenCaptureKit (WIP) |
 
-Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs).
+Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs)
+(VMX SIMD path reporting via `simd_path()`: `avx2` / `sse128` / `neon` / `scalar`).
 
 ## Prerequisites
 

--- a/crates/omt-media/Cargo.toml
+++ b/crates/omt-media/Cargo.toml
@@ -18,3 +18,4 @@ tracing.workspace = true
 vmx.workspace = true
 
 [dev-dependencies]
+suite-core.workspace = true

--- a/crates/omt-media/src/lib.rs
+++ b/crates/omt-media/src/lib.rs
@@ -28,4 +28,7 @@ pub use openmediatransport::{
     MetadataFrame, Quality, ReceiverConfig, ReceiverSession, Sender, SenderConfig, SenderInfo,
     SessionState, SessionStatistics, Statistics, bgra_alpha_mask, bgra_to_rgba, bgra_to_rgba_into,
 };
-pub use vmx::{Codec as VmxCodec, Config as VmxConfig, Profile as VmxProfile};
+pub use vmx::{
+    Codec as VmxCodec, Config as VmxConfig, Profile as VmxProfile,
+    SimdCapabilities as VmxSimdCapabilities, SimdPath as VmxSimdPath,
+};

--- a/crates/omt-media/tests/vmx_simd.rs
+++ b/crates/omt-media/tests/vmx_simd.rs
@@ -1,0 +1,94 @@
+//! Verify bumped `vmx-rs` / `openmediatransport-rs` SIMD dispatch.
+
+use omt_media::{VmxCodec, VmxConfig, VmxProfile, VmxSimdPath};
+
+#[test]
+fn vmx_simd_path_reports_and_encodes() {
+    let enc = VmxCodec::new(VmxConfig {
+        width: 1920,
+        height: 1080,
+        profile: VmxProfile::OmtHq,
+        color_space: Default::default(),
+    })
+    .expect("create codec");
+
+    let path = enc.simd_path();
+    let caps = enc.simd_capabilities();
+    eprintln!(
+        "omt-media vmx path={path} caps={{ssse3:{},sse42:{},avx2:{},bmi2:{},neon:{}}}",
+        caps.ssse3, caps.sse42, caps.avx2, caps.bmi2, caps.neon
+    );
+
+    assert!(matches!(
+        path,
+        VmxSimdPath::Scalar | VmxSimdPath::Sse128 | VmxSimdPath::Avx2 | VmxSimdPath::Neon
+    ));
+    assert_eq!(path.to_string(), path.as_str());
+    assert_eq!(caps.select_path(960), path);
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        assert_ne!(path, VmxSimdPath::Neon);
+        if caps.avx2 && caps.bmi2 {
+            assert_eq!(path, VmxSimdPath::Avx2);
+        } else if caps.sse42 && caps.ssse3 {
+            assert_eq!(path, VmxSimdPath::Sse128);
+        }
+    }
+
+    // UV width not multiple of 16 must not select AVX2.
+    let odd = VmxCodec::new(VmxConfig::new(632, 64)).expect("odd width");
+    assert_ne!(odd.simd_path(), VmxSimdPath::Avx2);
+
+    let width = 256i32;
+    let height = 144i32;
+    let stride = (width as usize) * 2;
+    let mut uyvy = vec![128u8; stride * height as usize];
+    for y in 0..height as usize {
+        for x in (0..width as usize).step_by(2) {
+            let o = y * stride + x * 2;
+            uyvy[o] = 100;
+            uyvy[o + 1] = 16 + ((x + y) % 220) as u8;
+            uyvy[o + 2] = 140;
+            uyvy[o + 3] = 16 + ((x + 1 + y) % 220) as u8;
+        }
+    }
+
+    let mut small = VmxCodec::new(VmxConfig {
+        width,
+        height,
+        profile: VmxProfile::OmtLq,
+        color_space: Default::default(),
+    })
+    .unwrap();
+    let encode_path = small.simd_path();
+    small.encode_uyvy(&uyvy, stride).unwrap();
+    let mut bitstream = vec![0u8; 2 << 20];
+    let len = small.save_to(&mut bitstream).unwrap();
+    assert!(len > 16);
+
+    let mut dec = VmxCodec::new(VmxConfig::new(width, height)).unwrap();
+    assert_eq!(dec.simd_path(), encode_path);
+    dec.load_from(&bitstream[..len]).unwrap();
+    let mut out = vec![0u8; stride * height as usize];
+    dec.decode_uyvy(&mut out, stride).unwrap();
+    let mean: f32 = out.iter().map(|&b| b as f32).sum::<f32>() / out.len() as f32;
+    assert!(mean > 1.0, "decoded empty on path {encode_path}");
+}
+
+#[test]
+fn suite_core_path_label_aligns_with_vmx_capabilities() {
+    use suite_core::SimdCapabilities;
+
+    let host = SimdCapabilities::detect();
+    let codec = VmxCodec::new(VmxConfig::new(1920, 1080)).expect("codec");
+    let vmx_caps = codec.simd_capabilities();
+
+    assert_eq!(host.ssse3, vmx_caps.ssse3);
+    assert_eq!(host.sse42, vmx_caps.sse42);
+    assert_eq!(host.avx2, vmx_caps.avx2);
+    assert_eq!(host.bmi2, vmx_caps.bmi2);
+    assert_eq!(host.neon, vmx_caps.neon);
+    // Capability-preferred label (no UV gate) matches codec path for 1920-wide frames.
+    assert_eq!(host.preferred_path_label(), codec.simd_path().as_str());
+}

--- a/crates/suite-core/src/simd.rs
+++ b/crates/suite-core/src/simd.rs
@@ -1,14 +1,16 @@
 //! Runtime SIMD capability summary for diagnostics UI.
 //!
-//! Labels mirror the instruction families used by `vmx-rs` / `openmediatransport-rs`
-//! (SSE2 / SSSE3 convert, SSE4.2 FDCT, AVX2+BMI2 codec path, NEON on aarch64).
+//! Labels mirror the instruction families used by `vmx-rs` /
+//! `openmediatransport-rs`. Path selection follows `vmx::SimdCapabilities`
+//! (AVX2+BMI2 → SSE4.2+SSSE3 → NEON → Scalar). UV-width gating for AVX2 is
+//! applied later inside `vmx::Codec` and is not part of this host-only probe.
 
 /// Detected CPU features relevant to the OMT media stack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SimdCapabilities {
     /// SSE2 (x86_64 color convert).
     pub sse2: bool,
-    /// SSSE3 (x86_64 color convert / swizzle).
+    /// SSSE3 (x86_64 color convert / swizzle; also required for SSE128 codec).
     pub ssse3: bool,
     /// SSE4.2 (x86_64 FDCT path).
     pub sse42: bool,
@@ -69,16 +71,30 @@ impl SimdCapabilities {
         self.avx2 && self.bmi2
     }
 
-    /// Preferred encode/decode SIMD path label (matches `vmx::simd::dispatch`).
+    /// Whether the SSE128 codec path can run (SSE4.2 + SSSE3), matching `vmx`.
+    pub fn sse128_path(&self) -> bool {
+        self.sse42 && self.ssse3
+    }
+
+    /// Preferred encode/decode SIMD path id (same strings as `vmx::SimdPath`).
     pub fn preferred_path_label(&self) -> &'static str {
-        if self.avx2_path() {
-            "AVX2"
-        } else if self.sse42 {
-            "SSE4.2"
-        } else if self.neon {
-            "NEON"
-        } else {
-            "Scalar"
+        #[cfg(target_arch = "x86_64")]
+        {
+            if self.avx2_path() {
+                "avx2"
+            } else if self.sse128_path() {
+                "sse128"
+            } else {
+                "scalar"
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            if self.neon { "neon" } else { "scalar" }
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            "scalar"
         }
     }
 
@@ -108,7 +124,7 @@ impl SimdCapabilities {
 
     /// Compact one-line summary for stats / settings panels.
     ///
-    /// Example: `SSE2, SSSE3, SSE4.2, AVX2, BMI2 (path: AVX2)`.
+    /// Example: `SSE2, SSSE3, SSE4.2, AVX2, BMI2 (path: avx2)`.
     pub fn summary(&self) -> String {
         let available = self.available_labels();
         let features = if available.is_empty() {
@@ -128,9 +144,11 @@ mod tests {
     fn detect_returns_consistent_path() {
         let caps = SimdCapabilities::detect();
         let path = caps.preferred_path_label();
-        assert!(matches!(path, "AVX2" | "SSE4.2" | "NEON" | "Scalar"));
+        assert!(matches!(path, "avx2" | "sse128" | "neon" | "scalar"));
         if caps.avx2_path() {
-            assert_eq!(path, "AVX2");
+            assert_eq!(path, "avx2");
+        } else if caps.sse128_path() {
+            assert_eq!(path, "sse128");
         }
         let summary = caps.summary();
         assert!(summary.contains("path:"));


### PR DESCRIPTION
## Summary
- Bump `vmx` to `#9980d38c` and `openmediatransport` to `#8fa1408e` (AVX2/NEON plane dispatch + `simd_path` reporting).
- Align `suite-core` diagnostics with `vmx::SimdPath` ids (`avx2` / `sse128` / `neon` / `scalar`) and require SSSE3 for the SSE128 path.
- Re-export `VmxSimdPath` / `VmxSimdCapabilities` from `omt-media` and add encode/decode + capability alignment tests.

## Test plan
- [x] Local: `cargo test -p suite-core -p omt-media --test vmx_simd -- --nocapture` (host reported `path=avx2`)
- [x] Local: `cargo clippy -p suite-core -p omt-media --all-targets -- -D warnings`
- [x] Local: `cargo check -p omt-studio-monitor -p omt-test-patterns -p monitor-bench`
- [ ] CI: fmt / clippy-test matrix