### PR TITLE
Bump vmx-rs/openmediatransport-rs and hand off sender encode

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -38,6 +38,13 @@ jobs:
         with:
           bun-version: '1.2.19'
 
+      # tauri-bundler fetches NSIS with attohttpc (no retries). Prefetch with curl
+      # so Windows jobs do not fail on `io: Peer disconnected` after a long compile.
+      - name: Prefetch NSIS toolchain (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./scripts/ci/prefetch-nsis.ps1
+
       - name: Build sidecar tools
         run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ node_modules/
 .idea/
 *.pdb
 received_frames/
+# Local bench / PGO artifacts
+target/bench-results/
+target/pgo-data/
+**/merged.profdata
+**/*.profraw

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2248,7 +2248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5209,7 +5209,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6084,6 +6084,7 @@ dependencies = [
  "cpal",
  "openmediatransport",
  "parking_lot",
+ "suite-core",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6186,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#a8bc036d878c8aad422f3efe7934f5b7b688a62e"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#8fa1408e3cada1c53b1b9d33f1bd297ac94fe077"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -6874,7 +6875,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7420,7 +7421,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7486,7 +7487,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8196,7 +8197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8290,7 +8291,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9039,7 +9040,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9550,7 +9551,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9609,7 +9610,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9927,7 +9928,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs#6cf175070b372b77cd52236aca3b5da18439af85"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs#9980d38c541dea0ad7f9d5eff019f22d189c2c8c"
 dependencies = [
  "rayon",
  "thiserror 2.0.20",
@@ -10594,7 +10595,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -5209,7 +5209,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6123,7 +6123,6 @@ dependencies = [
  "suite-core",
  "tracing",
  "tracing-subscriber",
- "vmx",
 ]
 
 [[package]]
@@ -6187,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#8fa1408e3cada1c53b1b9d33f1bd297ac94fe077"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#55ffd08ab899f8017056886157fb0d130ab36d5c"
 dependencies = [
  "bytes",
  "mdns-sd",
@@ -8197,7 +8196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8291,7 +8290,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9551,7 +9550,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9610,7 +9609,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9928,7 +9927,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vmx"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/vmx-rs#9980d38c541dea0ad7f9d5eff019f22d189c2c8c"
+source = "git+https://github.com/MikanseiLaboratory/vmx-rs#d860377cf91646a0c165dfbddc4467f4ee02762b"
 dependencies = [
  "rayon",
  "thiserror 2.0.20",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Open Media Transport production utilities inspired by NDI Tools.
 | Test Patterns |  Send SMPTE-style patterns + tone over OMT |
 | Screen Capture |  Windows Graphics Capture / ScreenCaptureKit (WIP) |
 
-Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs).
+Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs)
+(VMX SIMD path reporting via `simd_path()`: `avx2` / `sse128` / `neon` / `scalar`).
 
 ## Prerequisites
 

--- a/apps/test-patterns/Cargo.toml
+++ b/apps/test-patterns/Cargo.toml
@@ -24,4 +24,3 @@ smallvec = "1"
 suite-core.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-vmx.workspace = true

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -15,14 +15,13 @@ use gpui::{
 };
 use image::{Frame, ImageBuffer, Rgba};
 use omt_media::{AudioToneConfig, SendSession, SendSessionConfig, SendStats};
-use openmediatransport::uyvy_to_rgba;
+use openmediatransport::{Quality, uyvy_to_rgba};
 use pattern_generator::{PatternKind, fill_uyvy, uyvy_from_image_path};
 use smallvec::smallvec;
 use suite_core::{
     Language, SimdCapabilities, TestPatternsConfig, load_test_patterns_config,
     reveal_in_file_manager, save_test_patterns_config, t,
 };
-use vmx::Profile;
 
 /// Frames for one full scroll cycle at ±100% animation speed.
 const ANIM_BASE_CYCLE_FRAMES: f32 = 300.0;
@@ -260,11 +259,11 @@ fn pattern_label(lang: Language, kind: PatternKind) -> &'static str {
     }
 }
 
-fn profile_label(profile: Profile) -> &'static str {
-    match profile {
-        Profile::OmtLq | Profile::Lq => "LQ",
-        Profile::OmtHq | Profile::Hq => "HQ",
-        _ => "SQ",
+fn quality_label(quality: Quality) -> &'static str {
+    match quality {
+        Quality::Low => "LQ",
+        Quality::High => "HQ",
+        Quality::Medium | Quality::Default => "SQ",
     }
 }
 
@@ -326,7 +325,7 @@ struct PatternsView {
     width: i32,
     height: i32,
     frame_rate: FrameRate,
-    profile: Profile,
+    quality: Quality,
     animate: bool,
     anim_speed_h_pct: i32,
     anim_speed_v_pct: i32,
@@ -392,7 +391,7 @@ impl PatternsView {
                 n: 30_000,
                 d: 1_001,
             },
-            profile: Profile::OmtSq,
+            quality: Quality::Medium,
             animate: true,
             anim_speed_h_pct: 100,
             anim_speed_v_pct: 100,
@@ -826,11 +825,11 @@ impl PatternsView {
         cx.notify();
     }
 
-    fn set_profile(&mut self, profile: Profile, cx: &mut Context<Self>) {
-        if self.profile == profile {
+    fn set_quality(&mut self, quality: Quality, cx: &mut Context<Self>) {
+        if self.quality == quality {
             return;
         }
-        self.profile = profile;
+        self.quality = quality;
         self.apply_settings();
         cx.notify();
     }
@@ -918,7 +917,7 @@ impl PatternsView {
             height: self.height,
             fps_n: self.frame_rate.n,
             fps_d: self.frame_rate.d,
-            profile: self.profile,
+            quality: self.quality,
             animate: self.animate && self.kind != PatternKind::Image,
             audio: AudioToneConfig {
                 sample_rate: self.sample_rate,
@@ -982,7 +981,7 @@ impl Render for PatternsView {
         let kind = self.kind;
         let tone_hz = self.tone_hz;
         let frame_rate = self.frame_rate;
-        let profile = self.profile;
+        let quality = self.quality;
         let open_menu = self.open_menu;
         let custom_menu = self.custom_menu;
         let thumbs = self.thumbs.clone();
@@ -1187,7 +1186,7 @@ impl Render for PatternsView {
                             frame_rate,
                             open_menu == Some(MenuKind::Fps),
                         ))
-                        .child(quality_control(cx, language, profile))
+                        .child(quality_control(cx, language, quality))
                         .child(level_control(
                             cx,
                             language,
@@ -2008,9 +2007,9 @@ fn fps_control(
 fn quality_control(
     cx: &mut Context<PatternsView>,
     language: Language,
-    selected: Profile,
+    selected: Quality,
 ) -> impl IntoElement {
-    let profiles = [Profile::OmtLq, Profile::OmtSq, Profile::OmtHq];
+    let qualities = [Quality::Low, Quality::Medium, Quality::High];
     div()
         .flex()
         .flex_col()
@@ -2026,19 +2025,19 @@ fn quality_control(
                 .flex()
                 .rounded_md()
                 .overflow_hidden()
-                .children(profiles.into_iter().map(|profile| {
-                    let active = selected == profile;
+                .children(qualities.into_iter().map(|quality| {
+                    let active = selected == quality;
                     div()
-                        .id(SharedString::from(profile_label(profile)))
+                        .id(SharedString::from(quality_label(quality)))
                         .px_3()
                         .py_1()
                         .bg(if active { rgb(0x2f6fed) } else { rgb(0x243041) })
                         .cursor_pointer()
                         .text_xs()
                         .font_weight(FontWeight::SEMIBOLD)
-                        .child(profile_label(profile))
+                        .child(quality_label(quality))
                         .on_click(cx.listener(move |this, _, _, cx| {
-                            this.set_profile(profile, cx);
+                            this.set_quality(quality, cx);
                         }))
                         .into_any_element()
                 })),

--- a/crates/capture-spike/src/capture.rs
+++ b/crates/capture-spike/src/capture.rs
@@ -69,11 +69,11 @@ impl CaptureProbe {
             Ok(Self {
                 backend: CaptureBackend::WindowsGraphicsCapture,
                 available: true,
-                notes: "Preferred backend: Windows Graphics Capture. OS picker / yellow border required. GPU frames must be mapped to CPU BGRA before UYVY+VMX.".into(),
+                notes: "Preferred backend: Windows Graphics Capture. OS picker / yellow border required. GPU frames map to CPU BGRA for Sender encode.".into(),
                 requirements: vec![
                     "Windows 10 1803+ (Win32 interop 1903+)".into(),
                     "User consent via Graphics Capture picker".into(),
-                    "BGRA→UYVY conversion before VMX encode".into(),
+                    "BGRA frames can be sent uncompressed to Sender".into(),
                 ],
             })
         } else if cfg!(target_os = "macos") {
@@ -85,7 +85,7 @@ impl CaptureProbe {
                     "macOS 12.3+".into(),
                     "Screen Recording permission".into(),
                     "NSScreenCaptureUsageDescription in Info.plist".into(),
-                    "BGRA→UYVY conversion before VMX encode".into(),
+                    "BGRA frames can be sent uncompressed to Sender".into(),
                 ],
             })
         } else {

--- a/crates/capture-spike/src/main.rs
+++ b/crates/capture-spike/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> anyhow::Result<()> {
                     info.frames, info.width, info.height, info.bgra_len
                 );
                 if info.frames > 0 {
-                    // Convert one BGRA frame path into UYVY to estimate encode prep cost.
+                    // BGRA can be passed to Sender uncompressed. UYVY size is shown for comparison.
                     let rgb_w = info.width.max(2);
                     let rgb_h = info.height.max(1);
                     let mut dummy_rgb = vec![16u8; (rgb_w * rgb_h * 3) as usize];

--- a/crates/monitor-bench/Cargo.toml
+++ b/crates/monitor-bench/Cargo.toml
@@ -7,6 +7,10 @@ license.workspace = true
 authors.workspace = true
 description = "Headless Studio Monitor present-path performance harness"
 
+[[bin]]
+name = "monitor-bench"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/crates/monitor-bench/src/main.rs
+++ b/crates/monitor-bench/src/main.rs
@@ -1,0 +1,50 @@
+//! Headless Studio Monitor present-path CLI.
+//!
+//! Example:
+//!   cargo run --release -p monitor-bench -- --url omt://127.0.0.1:1234/source --duration 10 --backend null
+
+use std::time::Duration;
+
+use anyhow::Result;
+use clap::Parser;
+use monitor_bench::{BenchBackend, BenchOptions, print_report, run_headless};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "monitor-bench",
+    about = "Headless OMT receive + present harness"
+)]
+struct Args {
+    /// Source URL (`omt://…`).
+    #[arg(long)]
+    url: String,
+
+    /// Present backend simulation.
+    #[arg(long, value_enum, default_value_t = BenchBackend::Null)]
+    backend: BenchBackend,
+
+    /// Measurement window after the first frame, in seconds.
+    #[arg(long, default_value_t = 10.0)]
+    duration: f64,
+
+    /// Timeout waiting for the first frame, in seconds.
+    #[arg(long, default_value_t = 15.0)]
+    connect_timeout: f64,
+
+    /// Allow finishing with zero frames (CI dry-run).
+    #[arg(long, default_value_t = false)]
+    allow_zero_frames: bool,
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let report = run_headless(BenchOptions {
+        backend: args.backend,
+        url: args.url,
+        duration: Duration::from_secs_f64(args.duration.max(0.1)),
+        connect_timeout: Duration::from_secs_f64(args.connect_timeout.max(0.1)),
+        allow_zero_frames: args.allow_zero_frames,
+    })?;
+    print_report(&report);
+    Ok(())
+}

--- a/crates/omt-media/Cargo.toml
+++ b/crates/omt-media/Cargo.toml
@@ -18,3 +18,4 @@ tracing.workspace = true
 vmx.workspace = true
 
 [dev-dependencies]
+suite-core.workspace = true

--- a/crates/omt-media/src/lib.rs
+++ b/crates/omt-media/src/lib.rs
@@ -28,4 +28,7 @@ pub use openmediatransport::{
     MetadataFrame, Quality, ReceiverConfig, ReceiverSession, Sender, SenderConfig, SenderInfo,
     SessionState, SessionStatistics, Statistics, bgra_alpha_mask, bgra_to_rgba, bgra_to_rgba_into,
 };
-pub use vmx::{Codec as VmxCodec, Config as VmxConfig, Profile as VmxProfile};
+pub use vmx::{
+    Codec as VmxCodec, Config as VmxConfig, Profile as VmxProfile,
+    SimdCapabilities as VmxSimdCapabilities, SimdPath as VmxSimdPath,
+};

--- a/crates/omt-media/src/send.rs
+++ b/crates/omt-media/src/send.rs
@@ -8,10 +8,9 @@ use std::time::{Duration, Instant};
 
 use openmediatransport::{
     Codec, ColorSpace, Discovery, FrameType, MediaFrame, NETWORK_ASYNC_COUNT, NETWORK_SEND_BUFFER,
-    NETWORK_SEND_RECEIVE_BUFFER, OmtError, Sender, SenderConfig, SenderInfo,
+    NETWORK_SEND_RECEIVE_BUFFER, OmtError, Quality, Sender, SenderConfig, SenderInfo,
 };
 use parking_lot::Mutex;
-use vmx::{Codec as VmxCodec, Config as VmxConfig, Profile};
 
 use crate::runtime;
 
@@ -59,8 +58,8 @@ pub struct SendSessionConfig {
     pub fps_n: i32,
     /// Frame rate denominator.
     pub fps_d: i32,
-    /// VMX profile.
-    pub profile: Profile,
+    /// Encoding quality.
+    pub quality: Quality,
     /// Whether UYVY content changes every frame.
     pub animate: bool,
     /// Audio tone settings.
@@ -75,7 +74,7 @@ impl Default for SendSessionConfig {
             height: 1080,
             fps_n: 30,
             fps_d: 1,
-            profile: Profile::OmtSq,
+            quality: Quality::Medium,
             animate: true,
             audio: AudioToneConfig::default(),
         }
@@ -141,6 +140,7 @@ impl SendSession {
                 "MikanseiLaboratory",
                 env!("CARGO_PKG_VERSION"),
             ));
+            s.set_quality(config.quality);
         }
         let port = sender.lock().port();
         {
@@ -221,11 +221,11 @@ impl SendSession {
     /// Enable / disable per-frame content changes without restarting OMT.
     pub fn set_animate(&self, animate: bool) {
         self.animate.store(animate, Ordering::Relaxed);
-        // Drop any still-frame encode cache so the next frame matches.
+        // Drop any still-frame cache so the next frame matches.
         self.content_epoch.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Invalidate a cached still encode (pattern / image changed while not animating).
+    /// Invalidate a cached still frame (pattern / image changed while not animating).
     pub fn invalidate_content(&self) {
         self.content_epoch.fetch_add(1, Ordering::Relaxed);
     }
@@ -322,23 +322,13 @@ async fn video_loop(
     stats: Arc<Mutex<SendStats>>,
     epoch: Instant,
 ) {
-    let Ok(mut vmx) = VmxCodec::new(VmxConfig {
-        width: cfg.width,
-        height: cfg.height,
-        profile: cfg.profile,
-        color_space: vmx::ColorSpace::Undefined,
-    }) else {
-        return;
-    };
-
     let stride = (cfg.width as usize) * 2;
     let frame_bytes = stride * cfg.height as usize;
-    let mut vmx_buf = vec![0u8; 8 << 20];
     let mut cached: Option<(u64, Vec<u8>)> = None;
     let mut frame_idx = 0u64;
     let mut last_stats = Instant::now();
-    let mut encode_us_acc = 0u64;
-    let mut video_sent = 0u64;
+    let mut last_codec_time = 0i64;
+    let mut last_frames = 0i64;
     let video_interval =
         (cfg.fps_d as i64).saturating_mul(TICKS_PER_SECOND) / cfg.fps_n.max(1) as i64;
     let target_fps = cfg.fps_n as f64 / cfg.fps_d.max(1) as f64;
@@ -366,73 +356,46 @@ async fn video_loop(
 
         let animate = animate_flag.load(Ordering::Relaxed);
         let epoch_n = content_epoch.load(Ordering::Relaxed);
-        let t0 = Instant::now();
-        let payload = if !animate {
+        let uyvy = if !animate {
             if let Some((cached_epoch, data)) = cached.as_ref()
                 && *cached_epoch == epoch_n
             {
                 data.clone()
             } else {
-                let encode_result = tokio::task::block_in_place(|| {
-                    encode_provider_frame(
-                        &provider,
-                        frame_idx,
-                        &mut vmx,
-                        &mut vmx_buf,
-                        frame_bytes,
-                        stride,
-                    )
-                });
-                match encode_result {
-                    Some(p) => {
-                        cached = Some((epoch_n, p.clone()));
-                        p
-                    }
-                    None => {
-                        tokio::time::sleep(Duration::from_millis(5)).await;
-                        continue;
-                    }
-                }
-            }
-        } else {
-            cached = None;
-            let encode_result = tokio::task::block_in_place(|| {
-                encode_provider_frame(
-                    &provider,
-                    frame_idx,
-                    &mut vmx,
-                    &mut vmx_buf,
-                    frame_bytes,
-                    stride,
-                )
-            });
-            match encode_result {
-                Some(p) => p,
-                None => {
+                let frame = provider(frame_idx);
+                if frame.len() != frame_bytes {
                     tokio::time::sleep(Duration::from_millis(5)).await;
                     continue;
                 }
+                cached = Some((epoch_n, frame.clone()));
+                frame
             }
+        } else {
+            cached = None;
+            let frame = provider(frame_idx);
+            if frame.len() != frame_bytes {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                continue;
+            }
+            frame
         };
-        encode_us_acc += t0.elapsed().as_micros() as u64;
 
         let timestamp = (frame_idx as i64).saturating_mul(video_interval);
         let frame = MediaFrame {
             frame_type: FrameType::VIDEO,
             timestamp,
-            codec: Codec::Vmx1 as i32,
+            codec: Codec::Uyvy as i32,
             width: cfg.width,
             height: cfg.height,
+            stride: stride as i32,
             frame_rate_n: cfg.fps_n,
             frame_rate_d: cfg.fps_d,
             aspect_ratio: cfg.width as f32 / cfg.height.max(1) as f32,
             color_space: ColorSpace::Undefined,
-            data: payload,
+            data: uyvy,
             ..Default::default()
         };
-        if tokio::task::block_in_place(|| sender.lock().send_video(frame)).is_ok() {
-            video_sent += 1;
-        }
+        let _ = tokio::task::block_in_place(|| sender.lock().send_video(frame));
         frame_idx += 1;
 
         if last_stats.elapsed() >= STATS_INTERVAL {
@@ -448,13 +411,15 @@ async fn video_loop(
                     )
                 });
             let window = last_stats.elapsed().as_secs_f64().max(0.001);
-            let avg_ms = if video_sent > 0 {
-                (encode_us_acc as f64 / video_sent as f64) / 1000.0
+            let df = (st.frames - last_frames).max(0);
+            let dt = (st.codec_time - last_codec_time).max(0);
+            let avg_ms = if df > 0 {
+                (dt as f64 / df as f64) / 1000.0
             } else {
                 0.0
             };
             let mut snap = stats.lock();
-            snap.video_fps = (video_sent as f64 / window) as f32;
+            snap.video_fps = (df as f64 / window) as f32;
             snap.encode_ms = avg_ms as f32;
             snap.frames = st.frames;
             snap.dropped = st.frames_dropped;
@@ -465,33 +430,12 @@ async fn video_loop(
             snap.video_subscribers = video_subs;
             snap.audio_subscribers = audio_subs;
             snap.bytes_sent = st.bytes_sent;
-            encode_us_acc = 0;
-            video_sent = 0;
+            last_codec_time = st.codec_time;
+            last_frames = st.frames;
             last_stats = Instant::now();
         }
 
         tokio::task::yield_now().await;
-    }
-}
-
-fn encode_provider_frame(
-    provider: &FrameProvider,
-    frame_idx: u64,
-    vmx: &mut VmxCodec,
-    vmx_buf: &mut [u8],
-    frame_bytes: usize,
-    stride: usize,
-) -> Option<Vec<u8>> {
-    let uyvy = provider(frame_idx);
-    if uyvy.len() != frame_bytes {
-        return None;
-    }
-    if vmx.encode_uyvy(&uyvy, stride).is_err() {
-        return None;
-    }
-    match vmx.save_to(vmx_buf) {
-        Ok(n) => Some(vmx_buf[..n].to_vec()),
-        Err(_) => None,
     }
 }
 

--- a/crates/omt-media/tests/vmx_simd.rs
+++ b/crates/omt-media/tests/vmx_simd.rs
@@ -1,0 +1,94 @@
+//! Verify bumped `vmx-rs` / `openmediatransport-rs` SIMD dispatch.
+
+use omt_media::{VmxCodec, VmxConfig, VmxProfile, VmxSimdPath};
+
+#[test]
+fn vmx_simd_path_reports_and_encodes() {
+    let enc = VmxCodec::new(VmxConfig {
+        width: 1920,
+        height: 1080,
+        profile: VmxProfile::OmtHq,
+        color_space: Default::default(),
+    })
+    .expect("create codec");
+
+    let path = enc.simd_path();
+    let caps = enc.simd_capabilities();
+    eprintln!(
+        "omt-media vmx path={path} caps={{ssse3:{},sse42:{},avx2:{},bmi2:{},neon:{}}}",
+        caps.ssse3, caps.sse42, caps.avx2, caps.bmi2, caps.neon
+    );
+
+    assert!(matches!(
+        path,
+        VmxSimdPath::Scalar | VmxSimdPath::Sse128 | VmxSimdPath::Avx2 | VmxSimdPath::Neon
+    ));
+    assert_eq!(path.to_string(), path.as_str());
+    assert_eq!(caps.select_path(960), path);
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        assert_ne!(path, VmxSimdPath::Neon);
+        if caps.avx2 && caps.bmi2 {
+            assert_eq!(path, VmxSimdPath::Avx2);
+        } else if caps.sse42 && caps.ssse3 {
+            assert_eq!(path, VmxSimdPath::Sse128);
+        }
+    }
+
+    // UV width not multiple of 16 must not select AVX2.
+    let odd = VmxCodec::new(VmxConfig::new(632, 64)).expect("odd width");
+    assert_ne!(odd.simd_path(), VmxSimdPath::Avx2);
+
+    let width = 256i32;
+    let height = 144i32;
+    let stride = (width as usize) * 2;
+    let mut uyvy = vec![128u8; stride * height as usize];
+    for y in 0..height as usize {
+        for x in (0..width as usize).step_by(2) {
+            let o = y * stride + x * 2;
+            uyvy[o] = 100;
+            uyvy[o + 1] = 16 + ((x + y) % 220) as u8;
+            uyvy[o + 2] = 140;
+            uyvy[o + 3] = 16 + ((x + 1 + y) % 220) as u8;
+        }
+    }
+
+    let mut small = VmxCodec::new(VmxConfig {
+        width,
+        height,
+        profile: VmxProfile::OmtLq,
+        color_space: Default::default(),
+    })
+    .unwrap();
+    let encode_path = small.simd_path();
+    small.encode_uyvy(&uyvy, stride).unwrap();
+    let mut bitstream = vec![0u8; 2 << 20];
+    let len = small.save_to(&mut bitstream).unwrap();
+    assert!(len > 16);
+
+    let mut dec = VmxCodec::new(VmxConfig::new(width, height)).unwrap();
+    assert_eq!(dec.simd_path(), encode_path);
+    dec.load_from(&bitstream[..len]).unwrap();
+    let mut out = vec![0u8; stride * height as usize];
+    dec.decode_uyvy(&mut out, stride).unwrap();
+    let mean: f32 = out.iter().map(|&b| b as f32).sum::<f32>() / out.len() as f32;
+    assert!(mean > 1.0, "decoded empty on path {encode_path}");
+}
+
+#[test]
+fn suite_core_path_label_aligns_with_vmx_capabilities() {
+    use suite_core::SimdCapabilities;
+
+    let host = SimdCapabilities::detect();
+    let codec = VmxCodec::new(VmxConfig::new(1920, 1080)).expect("codec");
+    let vmx_caps = codec.simd_capabilities();
+
+    assert_eq!(host.ssse3, vmx_caps.ssse3);
+    assert_eq!(host.sse42, vmx_caps.sse42);
+    assert_eq!(host.avx2, vmx_caps.avx2);
+    assert_eq!(host.bmi2, vmx_caps.bmi2);
+    assert_eq!(host.neon, vmx_caps.neon);
+    // Capability-preferred label (no UV gate) matches codec path for 1920-wide frames.
+    assert_eq!(host.preferred_path_label(), codec.simd_path().as_str());
+}

--- a/crates/suite-core/src/simd.rs
+++ b/crates/suite-core/src/simd.rs
@@ -1,14 +1,16 @@
 //! Runtime SIMD capability summary for diagnostics UI.
 //!
-//! Labels mirror the instruction families used by `vmx-rs` / `openmediatransport-rs`
-//! (SSE2 / SSSE3 convert, SSE4.2 FDCT, AVX2+BMI2 codec path, NEON on aarch64).
+//! Labels mirror the instruction families used by `vmx-rs` /
+//! `openmediatransport-rs`. Path selection follows `vmx::SimdCapabilities`
+//! (AVX2+BMI2 → SSE4.2+SSSE3 → NEON → Scalar). UV-width gating for AVX2 is
+//! applied later inside `vmx::Codec` and is not part of this host-only probe.
 
 /// Detected CPU features relevant to the OMT media stack.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SimdCapabilities {
     /// SSE2 (x86_64 color convert).
     pub sse2: bool,
-    /// SSSE3 (x86_64 color convert / swizzle).
+    /// SSSE3 (x86_64 color convert / swizzle; also required for SSE128 codec).
     pub ssse3: bool,
     /// SSE4.2 (x86_64 FDCT path).
     pub sse42: bool,
@@ -69,16 +71,30 @@ impl SimdCapabilities {
         self.avx2 && self.bmi2
     }
 
-    /// Preferred encode/decode SIMD path label (matches `vmx::simd::dispatch`).
+    /// Whether the SSE128 codec path can run (SSE4.2 + SSSE3), matching `vmx`.
+    pub fn sse128_path(&self) -> bool {
+        self.sse42 && self.ssse3
+    }
+
+    /// Preferred encode/decode SIMD path id (same strings as `vmx::SimdPath`).
     pub fn preferred_path_label(&self) -> &'static str {
-        if self.avx2_path() {
-            "AVX2"
-        } else if self.sse42 {
-            "SSE4.2"
-        } else if self.neon {
-            "NEON"
-        } else {
-            "Scalar"
+        #[cfg(target_arch = "x86_64")]
+        {
+            if self.avx2_path() {
+                "avx2"
+            } else if self.sse128_path() {
+                "sse128"
+            } else {
+                "scalar"
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            if self.neon { "neon" } else { "scalar" }
+        }
+        #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+        {
+            "scalar"
         }
     }
 
@@ -108,7 +124,7 @@ impl SimdCapabilities {
 
     /// Compact one-line summary for stats / settings panels.
     ///
-    /// Example: `SSE2, SSSE3, SSE4.2, AVX2, BMI2 (path: AVX2)`.
+    /// Example: `SSE2, SSSE3, SSE4.2, AVX2, BMI2 (path: avx2)`.
     pub fn summary(&self) -> String {
         let available = self.available_labels();
         let features = if available.is_empty() {
@@ -128,9 +144,11 @@ mod tests {
     fn detect_returns_consistent_path() {
         let caps = SimdCapabilities::detect();
         let path = caps.preferred_path_label();
-        assert!(matches!(path, "AVX2" | "SSE4.2" | "NEON" | "Scalar"));
+        assert!(matches!(path, "avx2" | "sse128" | "neon" | "scalar"));
         if caps.avx2_path() {
-            assert_eq!(path, "AVX2");
+            assert_eq!(path, "avx2");
+        } else if caps.sse128_path() {
+            assert_eq!(path, "sse128");
         }
         let summary = caps.summary();
         assert!(summary.contains("path:"));

--- a/scripts/bench/pgo-build.ps1
+++ b/scripts/bench/pgo-build.ps1
@@ -1,0 +1,58 @@
+# Optional PGO build for OMT sidecars / monitor-bench.
+# Does NOT modify Cargo.toml profiles permanently.
+#
+# Usage (from omt-tools root, developer machine only):
+#   powershell -File scripts/bench/pgo-build.ps1
+#   powershell -File scripts/bench/pgo-build.ps1 -TrainSeconds 20
+#
+# Requires llvm-profdata on PATH (from LLVM or rustup llvm-tools).
+
+param(
+    [int]$TrainSeconds = 15,
+    [string]$ProfDir = "target/pgo-data"
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Set-Location $Root
+
+New-Item -ItemType Directory -Force -Path $ProfDir | Out-Null
+$ProfDirAbs = (Resolve-Path $ProfDir).Path
+$RawDir = Join-Path $ProfDirAbs "raw"
+New-Item -ItemType Directory -Force -Path $RawDir | Out-Null
+Get-ChildItem $RawDir -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
+
+Write-Host "==> Stage 1: instrumented build"
+$env:RUSTFLAGS = "-Cprofile-generate=$RawDir"
+cargo build --release -p monitor-bench -p omt-test-patterns -p omt-studio-monitor
+
+Write-Host "==> Stage 2: train (vmx simd_report + short sleep placeholder for live OMT)"
+Push-Location (Join-Path (Split-Path $Root -Parent) "vmx-rs")
+try {
+    $env:RUSTFLAGS = "-Cprofile-generate=$RawDir"
+    cargo build --release --example simd_report
+    cargo run --release --example simd_report -- 1920 1080 30 | Out-Host
+} finally {
+    Pop-Location
+}
+
+Write-Host "Optional live training: run test-patterns + monitor-bench for ~$TrainSeconds seconds while instrumented binaries are used."
+Start-Sleep -Seconds ([Math]::Min($TrainSeconds, 3))
+
+$merged = Join-Path $ProfDirAbs "merged.profdata"
+Write-Host "==> Stage 3: merge profiles -> $merged"
+$llvm = Get-Command llvm-profdata -ErrorAction SilentlyContinue
+if (-not $llvm) {
+    Write-Host "llvm-profdata not found on PATH. Install LLVM tools or:"
+    Write-Host "  rustup component add llvm-tools-preview"
+    Write-Host "Then re-run this script."
+    exit 1
+}
+& llvm-profdata merge -o $merged (Get-ChildItem $RawDir -Recurse -Filter *.profraw | ForEach-Object { $_.FullName })
+
+Write-Host "==> Stage 4: optimized build with profile-use"
+$env:RUSTFLAGS = "-Cprofile-use=$merged -Cllvm-args=-pgo-warn-missing-function"
+cargo build --release -p monitor-bench -p omt-test-patterns -p omt-studio-monitor
+
+Remove-Item Env:RUSTFLAGS -ErrorAction SilentlyContinue
+Write-Host "PGO build complete. Compare against scripts/bench/run-baseline.ps1 results."

--- a/scripts/bench/pgo-build.sh
+++ b/scripts/bench/pgo-build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Optional PGO build for OMT sidecars / monitor-bench.
+# Does NOT modify Cargo.toml profiles permanently.
+#
+# Usage (from omt-tools root):
+#   ./scripts/bench/pgo-build.sh
+# Requires llvm-profdata on PATH.
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+PROF_DIR="${PROF_DIR:-target/pgo-data}"
+RAW_DIR="$PROF_DIR/raw"
+mkdir -p "$RAW_DIR"
+rm -rf "$RAW_DIR"/*
+MERGED="$PROF_DIR/merged.profdata"
+
+echo "==> Stage 1: instrumented build"
+export RUSTFLAGS="-Cprofile-generate=$RAW_DIR"
+cargo build --release -p monitor-bench -p omt-test-patterns -p omt-studio-monitor
+
+echo "==> Stage 2: train with vmx simd_report"
+(
+  cd ../vmx-rs
+  export RUSTFLAGS="-Cprofile-generate=$RAW_DIR"
+  cargo build --release --example simd_report
+  cargo run --release --example simd_report -- 1920 1080 30
+)
+
+if ! command -v llvm-profdata >/dev/null 2>&1; then
+  echo "llvm-profdata not found. Install LLVM or: rustup component add llvm-tools-preview"
+  exit 1
+fi
+
+echo "==> Stage 3: merge profiles -> $MERGED"
+mapfile -t RAWS < <(find "$RAW_DIR" -name '*.profraw' -print)
+llvm-profdata merge -o "$MERGED" "${RAWS[@]}"
+
+echo "==> Stage 4: optimized build with profile-use"
+export RUSTFLAGS="-Cprofile-use=$MERGED -Cllvm-args=-pgo-warn-missing-function"
+cargo build --release -p monitor-bench -p omt-test-patterns -p omt-studio-monitor
+unset RUSTFLAGS
+
+echo "PGO build complete. Compare against scripts/bench/run-baseline.sh results."

--- a/scripts/bench/run-baseline.ps1
+++ b/scripts/bench/run-baseline.ps1
@@ -1,0 +1,47 @@
+# Build release sidecars/tools and run reproducible VMX / monitor-bench baselines.
+# Usage (from omt-tools root):
+#   powershell -File scripts/bench/run-baseline.ps1
+#   powershell -File scripts/bench/run-baseline.ps1 -Native
+#   powershell -File scripts/bench/run-baseline.ps1 -Width 1920 -Height 1080 -Iters 20
+
+param(
+    [switch]$Native,
+    [int]$Width = 1920,
+    [int]$Height = 1080,
+    [int]$Iters = 20,
+    [string]$OutDir = "target/bench-results"
+)
+
+$ErrorActionPreference = "Stop"
+$Root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Set-Location $Root
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$tag = if ($Native) { "native" } else { "release" }
+$outFile = Join-Path $OutDir "baseline-$tag-$stamp.txt"
+
+if ($Native) {
+    $env:RUSTFLAGS = "-C target-cpu=native"
+    Write-Host "RUSTFLAGS=$env:RUSTFLAGS"
+} else {
+    Remove-Item Env:RUSTFLAGS -ErrorAction SilentlyContinue
+}
+
+Write-Host "==> Building vmx simd_report ($tag)"
+Push-Location (Join-Path (Split-Path $Root -Parent) "vmx-rs")
+try {
+    cargo build --release --example simd_report
+    $report = cargo run --release --example simd_report -- $Width $Height $Iters 2>&1 |
+        Tee-Object -FilePath $outFile
+    Write-Host $report
+} finally {
+    Pop-Location
+}
+
+Write-Host "==> Building omt-tools monitor-bench ($tag)"
+cargo build --release -p monitor-bench -p omt-test-patterns 2>&1 | Tee-Object -FilePath $outFile -Append
+
+Write-Host "Results written to $outFile"
+Write-Host "Tip: start omt-test-patterns, then:"
+Write-Host "  cargo run --release -p monitor-bench -- --url omt://127.0.0.1:PORT/name --duration 10 --backend null"

--- a/scripts/bench/run-baseline.sh
+++ b/scripts/bench/run-baseline.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build release tools and run reproducible VMX baselines.
+# Usage (from omt-tools root):
+#   ./scripts/bench/run-baseline.sh
+#   NATIVE=1 ./scripts/bench/run-baseline.sh
+#   ./scripts/bench/run-baseline.sh 1920 1080 20
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+
+WIDTH="${1:-1920}"
+HEIGHT="${2:-1080}"
+ITERS="${3:-20}"
+OUT_DIR="${OUT_DIR:-target/bench-results}"
+mkdir -p "$OUT_DIR"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+TAG="release"
+if [[ "${NATIVE:-0}" == "1" ]]; then
+  export RUSTFLAGS="-C target-cpu=native"
+  TAG="native"
+  echo "RUSTFLAGS=$RUSTFLAGS"
+else
+  unset RUSTFLAGS || true
+fi
+
+OUT_FILE="$OUT_DIR/baseline-$TAG-$STAMP.txt"
+
+echo "==> Building vmx simd_report ($TAG)"
+(
+  cd ../vmx-rs
+  cargo build --release --example simd_report
+  cargo run --release --example simd_report -- "$WIDTH" "$HEIGHT" "$ITERS" | tee "$ROOT/$OUT_FILE"
+)
+
+echo "==> Building omt-tools monitor-bench ($TAG)"
+cargo build --release -p monitor-bench -p omt-test-patterns | tee -a "$OUT_FILE"
+
+echo "Results written to $OUT_FILE"
+echo "Tip: start omt-test-patterns, then:"
+echo "  cargo run --release -p monitor-bench -- --url omt://127.0.0.1:PORT/name --duration 10 --backend null"

--- a/scripts/ci/prefetch-nsis.ps1
+++ b/scripts/ci/prefetch-nsis.ps1
@@ -1,0 +1,67 @@
+# Prefetch Tauri's NSIS 3.11 toolchain into %LOCALAPPDATA%\tauri\NSIS.
+# tauri-bundler downloads this with attohttpc (no retries) and CI often fails with
+# `io: Peer disconnected` while fetching nsis-3.11.zip from GitHub.
+
+$ErrorActionPreference = "Stop"
+
+$tools = Join-Path $env:LOCALAPPDATA "tauri"
+$nsis = Join-Path $tools "NSIS"
+$dllRel = "Plugins\x86-unicode\additional\nsis_tauri_utils.dll"
+$dllPath = Join-Path $nsis $dllRel
+
+# Hashes match @tauri-apps/cli 2.11.x (tauri-bundler nsis/mod.rs).
+$nsisUrl = "https://github.com/tauri-apps/binary-releases/releases/download/nsis-3.11/nsis-3.11.zip"
+$nsisSha1 = "EF7FF767E5CBD9EDD22ADD3A32C9B8F4500BB10D"
+$dllUrl = "https://github.com/tauri-apps/nsis-tauri-utils/releases/download/nsis_tauri_utils-v0.5.3/nsis_tauri_utils.dll"
+$dllSha1 = "75197FEE3C6A814FE035788D1C34EAD39349B860"
+
+function Get-Sha1([string]$Path) {
+    (Get-FileHash -Algorithm SHA1 -Path $Path).Hash
+}
+
+function Invoke-Download([string]$Url, [string]$Out, [string]$ExpectedSha1) {
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Out) | Out-Null
+    $attempt = 0
+    while ($true) {
+        $attempt++
+        if (Test-Path $Out) { Remove-Item $Out -Force }
+        Write-Host "Downloading $Url (attempt $attempt)"
+        & curl.exe -L --fail --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 -o $Out $Url
+        if ($LASTEXITCODE -eq 0 -and (Test-Path $Out)) {
+            $actual = Get-Sha1 $Out
+            if ($actual -eq $ExpectedSha1) { return }
+            Write-Warning "SHA1 mismatch for $Url (got $actual, want $ExpectedSha1)"
+        }
+        if ($attempt -ge 4) {
+            throw "failed to download $Url after $attempt attempts"
+        }
+        Start-Sleep -Seconds (10 * $attempt)
+    }
+}
+
+$makensis = Join-Path $nsis "makensis.exe"
+if ((Test-Path $makensis) -and (Test-Path $dllPath)) {
+    Write-Host "NSIS already present at $nsis"
+    exit 0
+}
+
+New-Item -ItemType Directory -Force -Path $tools | Out-Null
+$zip = Join-Path $env:TEMP "nsis-3.11.zip"
+Invoke-Download $nsisUrl $zip $nsisSha1
+
+if (Test-Path $nsis) { Remove-Item $nsis -Recurse -Force }
+$extract = Join-Path $env:TEMP "nsis-extract"
+if (Test-Path $extract) { Remove-Item $extract -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $extract | Out-Null
+Expand-Archive -Path $zip -DestinationPath $extract -Force
+$extracted = Join-Path $extract "nsis-3.11"
+if (-not (Test-Path $extracted)) {
+    throw "zip did not contain nsis-3.11"
+}
+Move-Item $extracted $nsis
+
+$dllTmp = Join-Path $env:TEMP "nsis_tauri_utils.dll"
+Invoke-Download $dllUrl $dllTmp $dllSha1
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $dllPath) | Out-Null
+Copy-Item $dllTmp $dllPath -Force
+Write-Host "NSIS ready at $nsis"


### PR DESCRIPTION
## Summary
- Remove local `[patch]` path overrides so CI uses GitHub `vmx-rs` and `openmediatransport-rs`.
- Lock `vmx` to `d860377` and `openmediatransport` to `55ffd08` (SIMD IDCT + sender-encode merges).
- Hand uncompressed send off to `Sender::send_video` encode (UYVY in, quality via `Sender::set_quality`).
- Includes prior AVX2/NEON path reporting from #25.

This supersedes #25.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike -p omt-studio-monitor -p omt-test-patterns --all-targets -- -D warnings`
- [x] `cargo test -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike`
- [x] `cargo check -p omt-launcher`