### PR TITLE
Keep Test Patterns sending when settings change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6117,6 +6117,7 @@ dependencies = [
  "image",
  "omt-media",
  "openmediatransport",
+ "parking_lot",
  "pattern-generator",
  "rfd",
  "smallvec",

--- a/apps/test-patterns/Cargo.toml
+++ b/apps/test-patterns/Cargo.toml
@@ -18,6 +18,7 @@ gpui.workspace = true
 image.workspace = true
 omt-media.workspace = true
 openmediatransport.workspace = true
+parking_lot.workspace = true
 pattern-generator.workspace = true
 rfd = "0.15"
 smallvec = "1"

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -791,14 +791,15 @@ impl PatternsView {
 
     fn set_frame_rate(&mut self, frame_rate: FrameRate, cx: &mut Context<Self>) {
         self.open_menu = None;
+        if self.session.is_some() {
+            cx.notify();
+            return;
+        }
         if self.frame_rate == frame_rate {
             cx.notify();
             return;
         }
         self.frame_rate = frame_rate;
-        if let Some(session) = self.session.as_ref() {
-            session.set_frame_rate(frame_rate.n, frame_rate.d);
-        }
         cx.notify();
     }
 
@@ -898,8 +899,8 @@ impl PatternsView {
     fn toggle_menu(&mut self, menu: MenuKind, cx: &mut Context<Self>) {
         self.custom_menu = None;
         self.name_editing = false;
-        if self.session.is_some() && menu == MenuKind::Resolution {
-            if self.open_menu == Some(MenuKind::Resolution) {
+        if self.session.is_some() && matches!(menu, MenuKind::Resolution | MenuKind::Fps) {
+            if self.open_menu == Some(menu) {
                 self.open_menu = None;
             }
             cx.notify();
@@ -1332,6 +1333,7 @@ impl Render for PatternsView {
                             language,
                             frame_rate,
                             open_menu == Some(MenuKind::Fps),
+                            sending,
                         ))
                         .child(frame_buffer_control(cx, language, frame_buffer_frames))
                         .child(quality_control(cx, language, quality))
@@ -2170,6 +2172,7 @@ fn fps_control(
     language: Language,
     selected: FrameRate,
     open: bool,
+    locked: bool,
 ) -> impl IntoElement {
     div()
         .flex()
@@ -2189,11 +2192,14 @@ fn fps_control(
                 .py_1()
                 .rounded_md()
                 .bg(if open { rgb(0x2f6fed) } else { rgb(0x243041) })
+                .opacity(if locked { 0.55 } else { 1.0 })
                 .cursor_pointer()
                 .text_xs()
                 .child(selected.label())
-                .on_click(cx.listener(|this, _, _, cx| {
-                    this.toggle_menu(MenuKind::Fps, cx);
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    if !locked {
+                        this.toggle_menu(MenuKind::Fps, cx);
+                    }
                 })),
         )
 }

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -19,6 +19,7 @@ use omt_media::{
     SendSessionConfig, SendStats, clamp_video_frame_buffer_frames,
 };
 use openmediatransport::{Quality, uyvy_to_rgba};
+use parking_lot::Mutex;
 use pattern_generator::{PatternKind, fill_uyvy, uyvy_from_image_path};
 use smallvec::smallvec;
 use suite_core::{
@@ -28,6 +29,43 @@ use suite_core::{
 
 /// Frames for one full scroll cycle at ±100% animation speed.
 const ANIM_BASE_CYCLE_FRAMES: f32 = 300.0;
+
+/// Advance an independent scroll phase without resetting on speed changes.
+fn advance_scroll_phase(phase: f32, speed_pct: f32) -> f32 {
+    let step = speed_pct.clamp(-200.0, 200.0) / 100.0 / ANIM_BASE_CYCLE_FRAMES;
+    (phase + step).rem_euclid(1.0)
+}
+
+/// Live pattern pixels / animation, shared with the send provider.
+struct LivePattern {
+    kind: PatternKind,
+    image_uyvy: Option<Arc<Vec<u8>>>,
+    animate: bool,
+    speed_h: f32,
+    speed_v: f32,
+    phase_x: f32,
+    phase_y: f32,
+}
+
+impl LivePattern {
+    fn from_view(
+        kind: PatternKind,
+        animate: bool,
+        speed_h_pct: i32,
+        speed_v_pct: i32,
+        image_uyvy: Option<Arc<Vec<u8>>>,
+    ) -> Self {
+        Self {
+            kind,
+            image_uyvy,
+            animate: animate && kind != PatternKind::Image,
+            speed_h: speed_h_pct.clamp(-200, 200) as f32 / 100.0,
+            speed_v: speed_v_pct.clamp(-200, 200) as f32 / 100.0,
+            phase_x: 0.0,
+            phase_y: 0.0,
+        }
+    }
+}
 const THUMB_W: i32 = 320;
 const THUMB_H: i32 = 180;
 const PREVIEW_W: i32 = 240;
@@ -344,6 +382,7 @@ struct PatternsView {
     custom_images: Vec<CustomImage>,
     selected_custom: Option<usize>,
     session: Option<SendSession>,
+    live: Arc<Mutex<LivePattern>>,
     last_stats: SendStats,
     error: Option<SharedString>,
     thumbs: Vec<(PatternKind, Option<Arc<RenderImage>>)>,
@@ -411,6 +450,13 @@ impl PatternsView {
             custom_images,
             selected_custom: None,
             session: None,
+            live: Arc::new(Mutex::new(LivePattern::from_view(
+                PatternKind::SmpteColorBars,
+                true,
+                100,
+                100,
+                None,
+            ))),
             last_stats: SendStats::default(),
             error: None,
             thumbs,
@@ -457,14 +503,10 @@ impl PatternsView {
             );
             if self.last_preview_at.elapsed() >= frame_interval {
                 if self.animate {
-                    let step_h = self.anim_speed_h_pct.clamp(-200, 200) as f32
-                        / 100.0
-                        / ANIM_BASE_CYCLE_FRAMES;
-                    let step_v = self.anim_speed_v_pct.clamp(-200, 200) as f32
-                        / 100.0
-                        / ANIM_BASE_CYCLE_FRAMES;
-                    self.preview_phase_x = (self.preview_phase_x + step_h).rem_euclid(1.0);
-                    self.preview_phase_y = (self.preview_phase_y + step_v).rem_euclid(1.0);
+                    self.preview_phase_x =
+                        advance_scroll_phase(self.preview_phase_x, self.anim_speed_h_pct as f32);
+                    self.preview_phase_y =
+                        advance_scroll_phase(self.preview_phase_y, self.anim_speed_v_pct as f32);
                 }
                 self.refresh_preview(cx);
             }
@@ -510,7 +552,7 @@ impl PatternsView {
         }
         self.kind = kind;
         self.selected_custom = None;
-        self.apply_settings();
+        self.push_live_content(!self.animate);
         self.refresh_preview(cx);
         cx.notify();
     }
@@ -541,7 +583,7 @@ impl PatternsView {
         self.selected_custom = Some(index);
         self.kind = PatternKind::Image;
         self.error = None;
-        self.apply_settings();
+        self.push_live_content(true);
         cx.notify();
     }
 
@@ -634,7 +676,7 @@ impl PatternsView {
         if was_selected {
             self.selected_custom = None;
             self.kind = PatternKind::SmpteColorBars;
-            self.apply_settings();
+            self.push_live_content(!self.animate);
             self.refresh_preview(cx);
         }
         cx.notify();
@@ -660,7 +702,9 @@ impl PatternsView {
         }
         self.frame_buffer_frames = next;
         self.persist_images();
-        self.apply_settings();
+        if let Some(session) = self.session.as_ref() {
+            session.set_frame_buffer_frames(next);
+        }
         cx.notify();
     }
 
@@ -695,11 +739,14 @@ impl PatternsView {
         if self.name.trim().is_empty() {
             self.name = "Test Pattern".into();
         }
-        self.apply_settings();
         cx.notify();
     }
 
     fn begin_edit_name(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.session.is_some() {
+            cx.notify();
+            return;
+        }
         self.open_menu = None;
         self.custom_menu = None;
         self.name_editing = true;
@@ -738,7 +785,7 @@ impl PatternsView {
             return;
         }
         self.tone_hz = hz;
-        self.apply_settings();
+        self.push_live_audio();
         cx.notify();
     }
 
@@ -749,24 +796,33 @@ impl PatternsView {
             return;
         }
         self.frame_rate = frame_rate;
-        self.apply_settings();
+        if let Some(session) = self.session.as_ref() {
+            session.set_frame_rate(frame_rate.n, frame_rate.d);
+        }
         cx.notify();
     }
 
     fn set_resolution(&mut self, resolution: Resolution, cx: &mut Context<Self>) {
         self.open_menu = None;
+        if self.session.is_some() {
+            cx.notify();
+            return;
+        }
         if self.width == resolution.width && self.height == resolution.height {
             cx.notify();
             return;
         }
         self.width = resolution.width;
         self.height = resolution.height;
-        self.apply_settings();
         self.refresh_title();
         cx.notify();
     }
 
     fn nudge_width(&mut self, delta: i32, cx: &mut Context<Self>) {
+        if self.session.is_some() {
+            cx.notify();
+            return;
+        }
         let next = (self.width + delta).clamp(64, 7680);
         // Keep even width for UYVY.
         let next = next - (next % 2);
@@ -775,19 +831,21 @@ impl PatternsView {
             return;
         }
         self.width = next;
-        self.apply_settings();
         self.refresh_title();
         cx.notify();
     }
 
     fn nudge_height(&mut self, delta: i32, cx: &mut Context<Self>) {
+        if self.session.is_some() {
+            cx.notify();
+            return;
+        }
         let next = (self.height + delta).clamp(64, 4320);
         if next == self.height {
             cx.notify();
             return;
         }
         self.height = next;
-        self.apply_settings();
         self.refresh_title();
         cx.notify();
     }
@@ -798,7 +856,7 @@ impl PatternsView {
             self.preview_phase_x = 0.0;
             self.preview_phase_y = 0.0;
         }
-        self.apply_settings();
+        self.push_live_content(true);
         self.refresh_preview(cx);
         cx.notify();
     }
@@ -810,7 +868,7 @@ impl PatternsView {
             return;
         }
         self.anim_speed_h_pct = next;
-        self.apply_settings();
+        self.push_live_speeds();
         cx.notify();
     }
 
@@ -821,7 +879,7 @@ impl PatternsView {
             return;
         }
         self.anim_speed_v_pct = next;
-        self.apply_settings();
+        self.push_live_speeds();
         cx.notify();
     }
 
@@ -833,13 +891,20 @@ impl PatternsView {
             return;
         }
         self.level_dbfs = dbfs;
-        self.apply_settings();
+        self.push_live_audio();
         cx.notify();
     }
 
     fn toggle_menu(&mut self, menu: MenuKind, cx: &mut Context<Self>) {
         self.custom_menu = None;
         self.name_editing = false;
+        if self.session.is_some() && menu == MenuKind::Resolution {
+            if self.open_menu == Some(MenuKind::Resolution) {
+                self.open_menu = None;
+            }
+            cx.notify();
+            return;
+        }
         self.open_menu = if self.open_menu == Some(menu) {
             None
         } else {
@@ -853,7 +918,9 @@ impl PatternsView {
             return;
         }
         self.quality = quality;
-        self.apply_settings();
+        if let Some(session) = self.session.as_ref() {
+            session.set_quality(quality);
+        }
         cx.notify();
     }
 
@@ -875,59 +942,113 @@ impl PatternsView {
         cx.notify();
     }
 
-    /// Restart the live session only when already sending.
-    fn apply_settings(&mut self) {
-        if self.session.is_some() {
-            self.restart_session();
-        }
-    }
-
     fn current_image_path(&self) -> Option<&Path> {
         self.selected_custom
             .and_then(|i| self.custom_images.get(i))
             .map(|img| img.path.as_path())
     }
 
-    fn restart_session(&mut self) {
-        self.stop();
-        self.error = None;
+    fn audio_config(&self) -> AudioToneConfig {
+        AudioToneConfig {
+            sample_rate: self.sample_rate,
+            channels: self.channels,
+            tone_hz: self.tone_hz,
+            level_dbfs: self.level_dbfs,
+            samples: self.samples,
+        }
+    }
 
-        let width = self.width;
-        let height = self.height;
-        let kind = self.kind;
-        let animate = self.animate;
-        let speed_h = self.anim_speed_h_pct.clamp(-200, 200) as f32 / 100.0;
-        let speed_v = self.anim_speed_v_pct.clamp(-200, 200) as f32 / 100.0;
-        let image_uyvy = if kind == PatternKind::Image {
-            match self.current_image_path() {
-                Some(path) => match uyvy_from_image_path(path, width, height) {
-                    Ok(buf) => Some(buf),
-                    Err(e) => {
-                        self.error = Some(SharedString::from(e.to_string()));
-                        return;
-                    }
-                },
-                None => {
-                    self.error = Some(SharedString::from("Select an image file first"));
-                    return;
+    fn load_image_uyvy(&self) -> std::result::Result<Arc<Vec<u8>>, SharedString> {
+        match self.current_image_path() {
+            Some(path) => match uyvy_from_image_path(path, self.width, self.height) {
+                Ok(buf) => Ok(Arc::new(buf)),
+                Err(e) => Err(SharedString::from(e.to_string())),
+            },
+            None => Err(SharedString::from("Select an image file first")),
+        }
+    }
+
+    /// Push pattern / image / animation into the shared provider state.
+    fn push_live_content(&mut self, invalidate_still: bool) -> bool {
+        let image_uyvy = if self.kind == PatternKind::Image {
+            match self.load_image_uyvy() {
+                Ok(buf) => Some(buf),
+                Err(e) => {
+                    self.error = Some(e);
+                    return false;
                 }
             }
         } else {
             None
         };
-
-        let provider: Arc<dyn Fn(u64) -> Vec<u8> + Send + Sync> = Arc::new(move |idx| {
-            if let Some(ref still) = image_uyvy {
-                return still.clone();
+        let animate = self.animate && self.kind != PatternKind::Image;
+        {
+            let mut live = self.live.lock();
+            live.kind = self.kind;
+            live.image_uyvy = image_uyvy;
+            live.animate = animate;
+            live.speed_h = self.anim_speed_h_pct.clamp(-200, 200) as f32 / 100.0;
+            live.speed_v = self.anim_speed_v_pct.clamp(-200, 200) as f32 / 100.0;
+            if !animate {
+                live.phase_x = 0.0;
+                live.phase_y = 0.0;
             }
-            let (phase_x, phase_y) = if animate {
-                let t = idx as f32;
-                (
-                    (t * speed_h / ANIM_BASE_CYCLE_FRAMES).rem_euclid(1.0),
-                    (t * speed_v / ANIM_BASE_CYCLE_FRAMES).rem_euclid(1.0),
-                )
-            } else {
-                (0.0, 0.0)
+        }
+        if let Some(session) = self.session.as_ref() {
+            session.set_animate(animate);
+            if invalidate_still || !animate {
+                session.invalidate_content();
+            }
+        }
+        true
+    }
+
+    fn push_live_speeds(&self) {
+        let mut live = self.live.lock();
+        live.speed_h = self.anim_speed_h_pct.clamp(-200, 200) as f32 / 100.0;
+        live.speed_v = self.anim_speed_v_pct.clamp(-200, 200) as f32 / 100.0;
+    }
+
+    fn push_live_audio(&self) {
+        if let Some(session) = self.session.as_ref() {
+            session.update_audio(self.audio_config());
+        }
+    }
+
+    fn restart_session(&mut self) {
+        self.stop();
+        self.error = None;
+        {
+            let mut live = self.live.lock();
+            live.phase_x = 0.0;
+            live.phase_y = 0.0;
+        }
+        if !self.push_live_content(true) {
+            return;
+        }
+
+        let width = self.width;
+        let height = self.height;
+        let live = Arc::clone(&self.live);
+        let provider: Arc<dyn Fn(u64) -> Vec<u8> + Send + Sync> = Arc::new(move |_idx| {
+            let (kind, phase_x, phase_y) = {
+                let mut state = live.lock();
+                if let Some(ref still) = state.image_uyvy {
+                    return still.as_ref().clone();
+                }
+                let kind = state.kind;
+                let (phase_x, phase_y) = if state.animate {
+                    let px = state.phase_x;
+                    let py = state.phase_y;
+                    state.phase_x =
+                        (state.phase_x + state.speed_h / ANIM_BASE_CYCLE_FRAMES).rem_euclid(1.0);
+                    state.phase_y =
+                        (state.phase_y + state.speed_v / ANIM_BASE_CYCLE_FRAMES).rem_euclid(1.0);
+                    (px, py)
+                } else {
+                    (0.0, 0.0)
+                };
+                (kind, phase_x, phase_y)
             };
             let mut buf = vec![0u8; (width as usize) * 2 * (height as usize)];
             fill_uyvy(kind, &mut buf, width, height, phase_x, phase_y);
@@ -943,13 +1064,7 @@ impl PatternsView {
             quality: self.quality,
             animate: self.animate && self.kind != PatternKind::Image,
             frame_buffer_frames: self.frame_buffer_frames,
-            audio: AudioToneConfig {
-                sample_rate: self.sample_rate,
-                channels: self.channels,
-                tone_hz: self.tone_hz,
-                level_dbfs: self.level_dbfs,
-                samples: self.samples,
-            },
+            audio: self.audio_config(),
         };
 
         match SendSession::start(config, provider) {
@@ -1154,7 +1269,13 @@ impl Render for PatternsView {
                                         .font_weight(FontWeight::BOLD)
                                         .child(t(language, "patterns.settings")),
                                 )
-                                .child(name_field(cx, language, &name, name_editing))
+                                .child(name_field(cx, language, &name, name_editing, sending))
+                                .children(sending.then(|| {
+                                    div()
+                                        .text_xs()
+                                        .text_color(rgb(0xf6c344))
+                                        .child(t(language, "patterns.restart_required"))
+                                }))
                                 .child(toggle_row(
                                     cx,
                                     "animate-toggle",
@@ -1198,6 +1319,7 @@ impl Render for PatternsView {
                             width,
                             height,
                             open_menu == Some(MenuKind::Resolution),
+                            sending,
                         ))
                         .child(tone_control(
                             cx,
@@ -1783,6 +1905,7 @@ fn name_field(
     language: Language,
     name: &str,
     editing: bool,
+    locked: bool,
 ) -> impl IntoElement {
     let display = if editing {
         format!("{name}|")
@@ -1812,11 +1935,14 @@ fn name_field(
                     rgb(0x2a3340)
                 })
                 .bg(rgb(0x0c1016))
+                .opacity(if locked { 0.55 } else { 1.0 })
                 .cursor_text()
                 .text_xs()
                 .child(display)
-                .on_click(cx.listener(|this, _, window, cx| {
-                    this.begin_edit_name(window, cx);
+                .on_click(cx.listener(move |this, _, window, cx| {
+                    if !locked {
+                        this.begin_edit_name(window, cx);
+                    }
                 })),
         )
 }
@@ -1827,6 +1953,7 @@ fn resolution_control(
     width: i32,
     height: i32,
     open: bool,
+    locked: bool,
 ) -> impl IntoElement {
     div()
         .flex()
@@ -1846,11 +1973,14 @@ fn resolution_control(
                 .py_1()
                 .rounded_md()
                 .bg(if open { rgb(0x2f6fed) } else { rgb(0x243041) })
+                .opacity(if locked { 0.55 } else { 1.0 })
                 .cursor_pointer()
                 .text_xs()
                 .child(format!("{width}×{height}"))
-                .on_click(cx.listener(|this, _, _, cx| {
-                    this.toggle_menu(MenuKind::Resolution, cx);
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    if !locked {
+                        this.toggle_menu(MenuKind::Resolution, cx);
+                    }
                 })),
         )
 }
@@ -2156,4 +2286,21 @@ fn stat_row(label: &str, value: String) -> impl IntoElement {
                 .text_right()
                 .child(value),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn anim_speed_change_does_not_jump_phase() {
+        let start = 0.42;
+        let next_slow = advance_scroll_phase(start, 50.0);
+        let next_fast = advance_scroll_phase(start, 200.0);
+        let delta_slow = (next_slow - start).rem_euclid(1.0);
+        let delta_fast = (next_fast - start).rem_euclid(1.0);
+        assert!(delta_fast > delta_slow);
+        assert!(delta_fast < 0.02);
+        assert!((next_slow - start).abs() < 0.01);
+    }
 }

--- a/crates/omt-media/src/send.rs
+++ b/crates/omt-media/src/send.rs
@@ -3,7 +3,7 @@
 use std::collections::VecDeque;
 use std::f32::consts::TAU;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -134,6 +134,10 @@ pub struct SendSession {
     audio: Arc<Mutex<AudioToneConfig>>,
     animate: Arc<AtomicBool>,
     content_epoch: Arc<AtomicU64>,
+    sender: Arc<Mutex<Sender>>,
+    fps_n: Arc<AtomicI32>,
+    fps_d: Arc<AtomicI32>,
+    frame_buffer_frames: Arc<AtomicU32>,
     audio_join: Option<thread::JoinHandle<()>>,
     video_join: Option<thread::JoinHandle<()>>,
 }
@@ -181,6 +185,11 @@ impl SendSession {
         let audio = Arc::new(Mutex::new(config.audio.clone()));
         let animate = Arc::new(AtomicBool::new(config.animate));
         let content_epoch = Arc::new(AtomicU64::new(0));
+        let fps_n = Arc::new(AtomicI32::new(config.fps_n.max(1)));
+        let fps_d = Arc::new(AtomicI32::new(config.fps_d.max(1)));
+        let frame_buffer_frames = Arc::new(AtomicU32::new(clamp_video_frame_buffer_frames(
+            config.frame_buffer_frames,
+        ) as u32));
         let epoch = Instant::now();
 
         let audio_running = Arc::clone(&running);
@@ -195,6 +204,9 @@ impl SendSession {
         let video_stats = Arc::clone(&stats);
         let video_animate = Arc::clone(&animate);
         let video_epoch = Arc::clone(&content_epoch);
+        let video_fps_n = Arc::clone(&fps_n);
+        let video_fps_d = Arc::clone(&fps_d);
+        let video_buffer = Arc::clone(&frame_buffer_frames);
         let video_cfg = config.clone();
         let video_join = thread::Builder::new()
             .name("omt-send-video".into())
@@ -205,6 +217,9 @@ impl SendSession {
                     provider,
                     video_animate,
                     video_epoch,
+                    video_fps_n,
+                    video_fps_d,
+                    video_buffer,
                     video_running,
                     video_stats,
                     epoch,
@@ -217,6 +232,10 @@ impl SendSession {
             audio,
             animate,
             content_epoch,
+            sender,
+            fps_n,
+            fps_d,
+            frame_buffer_frames,
             audio_join: Some(audio_join),
             video_join: Some(video_join),
         })
@@ -246,6 +265,25 @@ impl SendSession {
     /// Invalidate a cached still frame (pattern / image changed while not animating).
     pub fn invalidate_content(&self) {
         self.content_epoch.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Hot-update encoding quality without tearing down the sender.
+    pub fn set_quality(&self, quality: Quality) {
+        self.sender.lock().set_quality(quality);
+    }
+
+    /// Hot-update output frame rate. Pacing and per-frame metadata follow.
+    pub fn set_frame_rate(&self, fps_n: i32, fps_d: i32) {
+        self.fps_n.store(fps_n.max(1), Ordering::Relaxed);
+        self.fps_d.store(fps_d.max(1), Ordering::Relaxed);
+    }
+
+    /// Hot-update paced video prefetch depth.
+    pub fn set_frame_buffer_frames(&self, frames: u32) {
+        self.frame_buffer_frames.store(
+            clamp_video_frame_buffer_frames(frames) as u32,
+            Ordering::Relaxed,
+        );
     }
 
     /// Stop tasks / threads.
@@ -335,11 +373,34 @@ fn duration_from_omt_ticks(ticks: i64) -> Duration {
     Duration::from_nanos(ticks.saturating_mul(100))
 }
 
+/// Frame interval in OMT ticks for `fps_n / fps_d`.
+fn video_interval_ticks(fps_n: i32, fps_d: i32) -> i64 {
+    (fps_d as i64).saturating_mul(TICKS_PER_SECOND) / fps_n.max(1) as i64
+}
+
 /// How many whole frame intervals fit in `elapsed` on the OMT tick timeline.
 fn frames_elapsed(elapsed: Duration, video_interval_ticks: i64) -> u64 {
     let interval = video_interval_ticks.max(1) as u128;
     let ticks = elapsed.as_nanos() / 100;
     (ticks / interval) as u64
+}
+
+/// Next paced index after a live frame-rate change.
+///
+/// Keeps timestamps on the shared wall clock and never steps backwards relative
+/// to `last_timestamp` (receivers drop or stall on non-monotonic PTS).
+fn next_frame_idx_after_rate_change(
+    elapsed: Duration,
+    new_interval_ticks: i64,
+    last_timestamp: i64,
+) -> u64 {
+    let interval = new_interval_ticks.max(1);
+    let wall_idx = frames_elapsed(elapsed, interval);
+    if last_timestamp < 0 {
+        return wall_idx;
+    }
+    let min_idx = (last_timestamp / interval) as u64 + 1;
+    wall_idx.max(min_idx)
 }
 
 /// Absolute deadline for `frame_idx` on a shared wall-clock epoch.
@@ -416,15 +477,17 @@ fn video_loop(
     provider: FrameProvider,
     animate_flag: Arc<AtomicBool>,
     content_epoch: Arc<AtomicU64>,
+    fps_n: Arc<AtomicI32>,
+    fps_d: Arc<AtomicI32>,
+    frame_buffer_frames: Arc<AtomicU32>,
     running: Arc<AtomicBool>,
     stats: Arc<Mutex<SendStats>>,
     epoch: Instant,
 ) {
     let stride = (cfg.width as usize) * 2;
     let frame_bytes = stride * cfg.height as usize;
-    let buffer_depth = clamp_video_frame_buffer_frames(cfg.frame_buffer_frames);
     let mut cached: Option<(u64, Vec<u8>)> = None;
-    let mut buffer: VecDeque<(u64, Vec<u8>)> = VecDeque::with_capacity(buffer_depth);
+    let mut buffer: VecDeque<(u64, Vec<u8>)> = VecDeque::new();
     let mut frame_idx = 0u64;
     let mut last_stats = Instant::now();
     let mut last_codec_time = 0i64;
@@ -432,13 +495,32 @@ fn video_loop(
     let mut behind = false;
     let mut was_subscribed = false;
     let mut last_content_epoch = content_epoch.load(Ordering::Relaxed);
-    let video_interval =
-        (cfg.fps_d as i64).saturating_mul(TICKS_PER_SECOND) / cfg.fps_n.max(1) as i64;
-    let target_fps = cfg.fps_n as f64 / cfg.fps_d.max(1) as f64;
+    let mut last_video_timestamp = -1i64;
+    let mut fps_n_now = fps_n.load(Ordering::Relaxed).max(1);
+    let mut fps_d_now = fps_d.load(Ordering::Relaxed).max(1);
+    let mut video_interval = video_interval_ticks(fps_n_now, fps_d_now);
+    let mut target_fps = fps_n_now as f64 / fps_d_now as f64;
     // Half a frame late still counts as the same slot; beyond that we skip ahead.
-    let late_slack = duration_from_omt_ticks(video_interval.max(1) / 2);
+    let mut late_slack = duration_from_omt_ticks(video_interval.max(1) / 2);
 
     while running.load(Ordering::Relaxed) {
+        let next_fps_n = fps_n.load(Ordering::Relaxed).max(1);
+        let next_fps_d = fps_d.load(Ordering::Relaxed).max(1);
+        if next_fps_n != fps_n_now || next_fps_d != fps_d_now {
+            fps_n_now = next_fps_n;
+            fps_d_now = next_fps_d;
+            video_interval = video_interval_ticks(fps_n_now, fps_d_now);
+            target_fps = fps_n_now as f64 / fps_d_now as f64;
+            late_slack = duration_from_omt_ticks(video_interval.max(1) / 2);
+            frame_idx = next_frame_idx_after_rate_change(
+                epoch.elapsed(),
+                video_interval,
+                last_video_timestamp,
+            );
+            buffer.clear();
+        }
+        let buffer_depth =
+            clamp_video_frame_buffer_frames(frame_buffer_frames.load(Ordering::Relaxed));
         let video_ok = {
             let mut s = sender.lock();
             let _ = s.poll_accept();
@@ -523,14 +605,15 @@ fn video_loop(
             width: cfg.width,
             height: cfg.height,
             stride: stride as i32,
-            frame_rate_n: cfg.fps_n,
-            frame_rate_d: cfg.fps_d,
+            frame_rate_n: fps_n_now,
+            frame_rate_d: fps_d_now,
             aspect_ratio: cfg.width as f32 / cfg.height.max(1) as f32,
             color_space: ColorSpace::Undefined,
             data: uyvy,
             ..Default::default()
         };
         let _ = sender.lock().send_video(frame);
+        last_video_timestamp = timestamp;
         frame_idx = frame_idx.saturating_add(1);
         let _ = fill_video_buffer(
             &mut buffer,
@@ -620,7 +703,7 @@ mod tests {
     use super::*;
 
     fn interval(fps_n: i32, fps_d: i32) -> i64 {
-        (fps_d as i64).saturating_mul(TICKS_PER_SECOND) / fps_n.max(1) as i64
+        video_interval_ticks(fps_n, fps_d)
     }
 
     #[test]
@@ -629,6 +712,29 @@ mod tests {
         assert_eq!(interval(60, 1), 166_666);
         assert_eq!(interval(30_000, 1_001), 333_666);
         assert_eq!(interval(60_000, 1_001), 166_833);
+    }
+
+    #[test]
+    fn rate_change_keeps_timestamps_monotonic() {
+        let iv30 = interval(30, 1);
+        let last_ts = 300 * iv30;
+        let elapsed = duration_from_omt_ticks(last_ts);
+        let iv60 = interval(60, 1);
+        let idx = next_frame_idx_after_rate_change(elapsed, iv60, last_ts);
+        let next_ts = (idx as i64).saturating_mul(iv60);
+        assert!(next_ts > last_ts, "next={next_ts} last={last_ts}");
+
+        let iv24 = interval(24, 1);
+        let idx_down = next_frame_idx_after_rate_change(elapsed, iv24, last_ts);
+        let next_down = (idx_down as i64).saturating_mul(iv24);
+        assert!(next_down > last_ts, "next={next_down} last={last_ts}");
+    }
+
+    #[test]
+    fn rate_change_without_prior_frame_follows_wall_clock() {
+        let iv = interval(30, 1);
+        let elapsed = duration_from_omt_ticks(iv.saturating_mul(10));
+        assert_eq!(next_frame_idx_after_rate_change(elapsed, iv, -1), 10);
     }
 
     #[test]

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -233,6 +233,12 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::Japanese, "patterns.stop") => "停止",
         (Language::English, "patterns.name") => "Source name",
         (Language::Japanese, "patterns.name") => "ソース名",
+        (Language::English, "patterns.restart_required") => {
+            "Stop sending to change the source name or resolution."
+        }
+        (Language::Japanese, "patterns.restart_required") => {
+            "ソース名と解像度を変更するには送出を停止してください"
+        }
         (Language::English, "patterns.pattern") => "Pattern",
         (Language::Japanese, "patterns.pattern") => "パターン",
         (Language::English, "patterns.animate") => "Animate",
@@ -351,6 +357,7 @@ mod tests {
             "tool.test_patterns",
             "monitor.stalled",
             "patterns.start",
+            "patterns.restart_required",
         ];
         for key in keys {
             assert_ne!(t(Language::English, key), key, "missing en key {key}");

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -234,10 +234,10 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::English, "patterns.name") => "Source name",
         (Language::Japanese, "patterns.name") => "ソース名",
         (Language::English, "patterns.restart_required") => {
-            "Stop sending to change the source name or resolution."
+            "Stop sending to change the source name, resolution, or framerate."
         }
         (Language::Japanese, "patterns.restart_required") => {
-            "ソース名と解像度を変更するには送出を停止してください"
+            "ソース名・解像度・フレームレートを変更するには送出を停止してください"
         }
         (Language::English, "patterns.pattern") => "Pattern",
         (Language::Japanese, "patterns.pattern") => "パターン",


### PR DESCRIPTION
## Summary
- Fixes https://github.com/MikanseiLaboratory/omt-tools/issues/26 by hot-updating the running OMT sender instead of restarting it on pattern, FPS, animation, tone, quality, or buffer changes.
- Locks source name and resolution while sending, with a warning that those require Stop first.
- Accumulates scroll phase so changing animation speed no longer jumps or resets position.

## Test plan
- [x] Start Test Patterns, receive in Studio Monitor or vMix
- [x] Change pattern, FPS, animation on/off, H/V speed, tone, level, quality, frame buffer while sending — receiver stays connected
- [x] Changing scroll speed does not jump/reset position
- [x] Source name and resolution are locked while sending, with the restart warning visible
- [x] Stop, change name/resolution, Start — new values take effect