### PR TITLE
Enable scroll animation for custom image patterns (#32)

### DIFF
--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -20,7 +20,7 @@ use omt_media::{
 };
 use openmediatransport::{Quality, uyvy_to_rgba};
 use parking_lot::Mutex;
-use pattern_generator::{PatternKind, fill_uyvy, uyvy_from_image_path};
+use pattern_generator::{PatternKind, fill_uyvy, scroll_uyvy, uyvy_from_image_path};
 use smallvec::smallvec;
 use suite_core::{
     Language, SimdCapabilities, TestPatternsConfig, load_test_patterns_config,
@@ -58,7 +58,7 @@ impl LivePattern {
         Self {
             kind,
             image_uyvy,
-            animate: animate && kind != PatternKind::Image,
+            animate,
             speed_h: speed_h_pct.clamp(-200, 200) as f32 / 100.0,
             speed_v: speed_v_pct.clamp(-200, 200) as f32 / 100.0,
             phase_x: 0.0,
@@ -387,6 +387,8 @@ struct PatternsView {
     error: Option<SharedString>,
     thumbs: Vec<(PatternKind, Option<Arc<RenderImage>>)>,
     preview: Option<Arc<RenderImage>>,
+    /// Preview-sized UYVY cache for the selected custom image (scroll source).
+    preview_image_uyvy: Option<Arc<Vec<u8>>>,
     preview_phase_x: f32,
     preview_phase_y: f32,
     last_preview_at: Instant,
@@ -462,6 +464,7 @@ impl PatternsView {
             error: None,
             thumbs,
             preview: None,
+            preview_image_uyvy: None,
             preview_phase_x: 0.0,
             preview_phase_y: 0.0,
             last_preview_at: Instant::now() - Duration::from_secs(1),
@@ -496,9 +499,9 @@ impl PatternsView {
         if let Some(session) = &self.session {
             self.last_stats = session.stats();
         }
-        // Still-image preview is loaded once at pick time; animate generated patterns
-        // at the selected output frame rate (was previously hard-capped at ~5 fps).
-        if self.kind != PatternKind::Image {
+        // Animate generated patterns and custom images at the selected output frame rate.
+        // Static image stills skip the tick until Animate is enabled.
+        if self.kind != PatternKind::Image || self.animate {
             let frame_interval = Duration::from_secs_f64(
                 self.frame_rate.d.max(1) as f64 / self.frame_rate.n.max(1) as f64,
             );
@@ -553,6 +556,7 @@ impl PatternsView {
         }
         self.kind = kind;
         self.selected_custom = None;
+        self.preview_image_uyvy = None;
         self.push_live_content(!self.animate);
         self.refresh_preview(cx);
         cx.notify();
@@ -568,23 +572,20 @@ impl PatternsView {
             return;
         };
         let path = entry.path.clone();
-        let preview = match rgba_image_from_path(&path, PREVIEW_W as u32, PREVIEW_H as u32) {
-            Ok(img) => img,
+        let preview_uyvy = match uyvy_from_image_path(&path, PREVIEW_W, PREVIEW_H) {
+            Ok(buf) => Arc::new(buf),
             Err(e) => {
-                self.error = Some(SharedString::from(e));
+                self.error = Some(SharedString::from(e.to_string()));
                 cx.notify();
                 return;
             }
         };
-        if let Some(old) = self.preview.take() {
-            cx.drop_image(old, None);
-        }
-        self.preview = Some(preview);
-        self.last_preview_at = Instant::now();
+        self.preview_image_uyvy = Some(preview_uyvy);
         self.selected_custom = Some(index);
         self.kind = PatternKind::Image;
         self.error = None;
         self.push_live_content(true);
+        self.refresh_preview(cx);
         cx.notify();
     }
 
@@ -676,6 +677,7 @@ impl PatternsView {
         }
         if was_selected {
             self.selected_custom = None;
+            self.preview_image_uyvy = None;
             self.kind = PatternKind::SmpteColorBars;
             self.push_live_content(!self.animate);
             self.refresh_preview(cx);
@@ -983,7 +985,7 @@ impl PatternsView {
         } else {
             None
         };
-        let animate = self.animate && self.kind != PatternKind::Image;
+        let animate = self.animate;
         {
             let mut live = self.live.lock();
             live.kind = self.kind;
@@ -1033,12 +1035,10 @@ impl PatternsView {
         let height = self.height;
         let live = Arc::clone(&self.live);
         let provider: Arc<dyn Fn(u64) -> Vec<u8> + Send + Sync> = Arc::new(move |_idx| {
-            let (kind, phase_x, phase_y) = {
+            let (kind, phase_x, phase_y, image) = {
                 let mut state = live.lock();
-                if let Some(ref still) = state.image_uyvy {
-                    return still.as_ref().clone();
-                }
                 let kind = state.kind;
+                let image = state.image_uyvy.clone();
                 let (phase_x, phase_y) = if state.animate {
                     let px = state.phase_x;
                     let py = state.phase_y;
@@ -1050,8 +1050,16 @@ impl PatternsView {
                 } else {
                     (0.0, 0.0)
                 };
-                (kind, phase_x, phase_y)
+                (kind, phase_x, phase_y, image)
             };
+            if let Some(still) = image {
+                if phase_x == 0.0 && phase_y == 0.0 {
+                    return still.as_ref().clone();
+                }
+                let mut buf = vec![0u8; (width as usize) * 2 * (height as usize)];
+                scroll_uyvy(still.as_ref(), &mut buf, width, height, phase_x, phase_y);
+                return buf;
+            }
             let mut buf = vec![0u8; (width as usize) * 2 * (height as usize)];
             fill_uyvy(kind, &mut buf, width, height, phase_x, phase_y);
             buf
@@ -1064,7 +1072,7 @@ impl PatternsView {
             fps_n: self.frame_rate.n,
             fps_d: self.frame_rate.d,
             quality: self.quality,
-            animate: self.animate && self.kind != PatternKind::Image,
+            animate: self.animate,
             frame_buffer_frames: self.frame_buffer_frames,
             audio: self.audio_config(),
         };
@@ -1083,17 +1091,27 @@ impl PatternsView {
 
     fn refresh_preview(&mut self, cx: &mut Context<Self>) {
         self.last_preview_at = Instant::now();
-        // Image stills are assigned once when selecting a custom image.
-        if self.kind == PatternKind::Image {
-            return;
-        }
         let (phase_x, phase_y) = if self.animate {
             (self.preview_phase_x, self.preview_phase_y)
         } else {
             (0.0, 0.0)
         };
-        let mut uyvy = vec![0u8; (PREVIEW_W as usize) * 2 * (PREVIEW_H as usize)];
-        fill_uyvy(self.kind, &mut uyvy, PREVIEW_W, PREVIEW_H, phase_x, phase_y);
+        let uyvy = if self.kind == PatternKind::Image {
+            let Some(src) = self.preview_image_uyvy.as_ref() else {
+                return;
+            };
+            if phase_x == 0.0 && phase_y == 0.0 {
+                src.as_ref().clone()
+            } else {
+                let mut buf = vec![0u8; (PREVIEW_W as usize) * 2 * (PREVIEW_H as usize)];
+                scroll_uyvy(src.as_ref(), &mut buf, PREVIEW_W, PREVIEW_H, phase_x, phase_y);
+                buf
+            }
+        } else {
+            let mut buf = vec![0u8; (PREVIEW_W as usize) * 2 * (PREVIEW_H as usize)];
+            fill_uyvy(self.kind, &mut buf, PREVIEW_W, PREVIEW_H, phase_x, phase_y);
+            buf
+        };
         let rgba = uyvy_to_rgba(&uyvy, PREVIEW_W as u32, PREVIEW_H as u32);
         if let Some(image) = rgba_to_render_image(rgba, PREVIEW_W as u32, PREVIEW_H as u32) {
             if let Some(old) = self.preview.take() {

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -1104,7 +1104,14 @@ impl PatternsView {
                 src.as_ref().clone()
             } else {
                 let mut buf = vec![0u8; (PREVIEW_W as usize) * 2 * (PREVIEW_H as usize)];
-                scroll_uyvy(src.as_ref(), &mut buf, PREVIEW_W, PREVIEW_H, phase_x, phase_y);
+                scroll_uyvy(
+                    src.as_ref(),
+                    &mut buf,
+                    PREVIEW_W,
+                    PREVIEW_H,
+                    phase_x,
+                    phase_y,
+                );
                 buf
             }
         } else {

--- a/crates/pattern-generator/src/lib.rs
+++ b/crates/pattern-generator/src/lib.rs
@@ -192,6 +192,45 @@ pub fn uyvy_from_image_path(
     ))
 }
 
+/// Toroidally scroll a UYVY frame by `phase_x` / `phase_y` in `0..1`.
+///
+/// Horizontal offset is forced even so UYVY chroma pairs stay aligned.
+pub fn scroll_uyvy(
+    src: &[u8],
+    dst: &mut [u8],
+    width: i32,
+    height: i32,
+    phase_x: f32,
+    phase_y: f32,
+) {
+    let w = width.max(2) as usize;
+    let h = height.max(1) as usize;
+    let stride = w * 2;
+    assert!(src.len() >= stride * h);
+    assert!(dst.len() >= stride * h);
+
+    let ox = phase_offset(phase_x, w) & !1;
+    let oy = phase_offset(phase_y, h);
+    if ox == 0 && oy == 0 {
+        dst[..stride * h].copy_from_slice(&src[..stride * h]);
+        return;
+    }
+
+    let byte_ox = ox * 2;
+    for y in 0..h {
+        let sy = (y + oy) % h;
+        let src_row = &src[sy * stride..(sy + 1) * stride];
+        let dst_row = &mut dst[y * stride..(y + 1) * stride];
+        if byte_ox == 0 {
+            dst_row.copy_from_slice(src_row);
+        } else {
+            let (head, tail) = src_row.split_at(byte_ox);
+            dst_row[..stride - byte_ox].copy_from_slice(tail);
+            dst_row[stride - byte_ox..].copy_from_slice(head);
+        }
+    }
+}
+
 fn phase_offset(phase: f32, extent: usize) -> usize {
     if phase == 0.0 || extent == 0 {
         0
@@ -430,5 +469,33 @@ mod tests {
         assert_ne!(a, b);
         assert_ne!(a, c);
         assert_ne!(b, c);
+    }
+
+    #[test]
+    fn scroll_uyvy_wraps_independently() {
+        let w = 64;
+        let h = 36;
+        let src = generate_uyvy(PatternKind::Grid, w, h, 0.0, 0.0);
+        let mut a = vec![0u8; src.len()];
+        let mut b = vec![0u8; src.len()];
+        let mut c = vec![0u8; src.len()];
+        scroll_uyvy(&src, &mut a, w, h, 0.0, 0.0);
+        scroll_uyvy(&src, &mut b, w, h, 0.5, 0.0);
+        scroll_uyvy(&src, &mut c, w, h, 0.0, 0.5);
+        assert_eq!(a, src);
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+    }
+
+    #[test]
+    fn scroll_uyvy_full_cycle_returns_original() {
+        let w = 32;
+        let h = 18;
+        let src = generate_uyvy(PatternKind::Grid, w, h, 0.0, 0.0);
+        let mut dst = vec![0u8; src.len()];
+        // phase that maps to ox=0 (even) and oy=0 after rem_euclid
+        scroll_uyvy(&src, &mut dst, w, h, 1.0, 1.0);
+        assert_eq!(dst, src);
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes #32 — custom image patterns now scroll with Animate / H speed / V speed, matching built-in patterns.

Previously the UI exposed animation controls for images, but every live path forced `animate = false` for `PatternKind::Image` and the send provider returned a static UYVY clone.

## Changes
- **`pattern-generator`**: add `scroll_uyvy` for toroidal H/V scroll of a cached UYVY frame (horizontal offset forced even for chroma pair alignment), plus unit tests
- **`omt-test-patterns`**: remove Image-specific animate guards in live state / session config / provider; scroll image frames when animate is on; animate the output preview from a preview-sized UYVY cache

## Test plan
- [x] Select a custom image in Test Patterns with Animate on — preview should scroll at H/V speeds
- [ ] Toggle Animate off — image should freeze at phase 0
- [x] Start sending while animating an image — Studio Monitor (or another receiver) should show the scrolling image
- [x] Switch between built-in patterns and images — animate behavior remains correct for both
- [x] `cargo test -p pattern-generator` passes
- [x] `cargo fmt --all -- --check` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-320dd6a4-aae8-42bd-9766-6053cbab9c6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-320dd6a4-aae8-42bd-9766-6053cbab9c6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

