### PR TITLE
Fix Test Patterns source name editing after send stop

### DIFF
--- a/apps/studio-monitor/src/app.rs
+++ b/apps/studio-monitor/src/app.rs
@@ -11,8 +11,8 @@ use eframe::egui::{
     Ui, Vec2,
 };
 use omt_media::{
-    AudioLevels, AudioOutputDevice, BufferUnit, ConnectOptions, DelaySetting, DiscoveredSource,
-    ReceiveWorker, SessionState, StallState, list_output_devices, spawn_discover,
+    AudioLevels, AudioOutputDevice, AudioOutputStatus, BufferUnit, ConnectOptions, DelaySetting,
+    DiscoveredSource, ReceiveWorker, SessionState, StallState, list_output_devices, spawn_discover,
 };
 use suite_core::{
     Language, SUITE_VERSION, SimdCapabilities, ThemePreference, install_egui_cjk_fonts,
@@ -601,6 +601,10 @@ impl MonitorApp {
         }
     }
 
+    fn audio_unavailable(&self) -> bool {
+        matches!(self.worker.audio().status(), AudioOutputStatus::Unavailable)
+    }
+
     fn open_preferences(&mut self) {
         self.preferences_open = true;
         self.audio_devices = list_output_devices();
@@ -765,6 +769,7 @@ impl eframe::App for MonitorApp {
                 &self.settings,
                 &self.audio_devices,
                 self.audio_output_device.as_deref(),
+                self.audio_unavailable(),
                 self.settings.buffer,
                 self.video_buffer_delay_ms,
                 self.audio_buffer_delay_ms,
@@ -937,6 +942,12 @@ impl MonitorApp {
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 12.0;
                     ui.label(RichText::new(&self.stall_text).color(chrome.text));
+                    if self.audio_unavailable() {
+                        ui.label(
+                            RichText::new(t(self.language, "monitor.audio_unavailable"))
+                                .color(chrome.text),
+                        );
+                    }
                     ui.label(
                         RichText::new(format!("{:.0}%", self.zoom * 100.0)).color(chrome.text),
                     );
@@ -945,9 +956,6 @@ impl MonitorApp {
                     }
                     if chip(ui, chrome, t(self.language, "monitor.fullscreen"), false) {
                         self.enter_fullscreen(ui.ctx());
-                    }
-                    if chip(ui, chrome, t(self.language, "monitor.preferences"), false) {
-                        self.open_preferences();
                     }
                     ui.label(
                         RichText::new(
@@ -1056,18 +1064,12 @@ impl MonitorApp {
 
                 ui.with_layout(egui::Layout::bottom_up(egui::Align::Center), |ui| {
                     ui.add_space(12.0);
-                    if ui
-                        .add(
-                            egui::Button::new(
-                                RichText::new(t(self.language, "monitor.preferences"))
-                                    .color(chrome.text),
-                            )
-                            .fill(chrome.surface)
-                            .corner_radius(6.0)
-                            .min_size(Vec2::new(ui.available_width(), 36.0)),
-                        )
-                        .clicked()
-                    {
+                    if prefs_button(
+                        ui,
+                        chrome,
+                        t(self.language, "monitor.preferences"),
+                        self.preferences_open,
+                    ) {
                         self.open_preferences();
                     }
                     ui.add_space(10.0);
@@ -1184,6 +1186,18 @@ impl MonitorApp {
                         stat_row(
                             ui,
                             chrome,
+                            t(self.language, "monitor.audio_output"),
+                            if self.audio_unavailable() {
+                                t(self.language, "monitor.audio_unavailable").to_string()
+                            } else {
+                                self.audio_output_device.clone().unwrap_or_else(|| {
+                                    t(self.language, "monitor.audio_default").to_string()
+                                })
+                            },
+                        );
+                        stat_row(
+                            ui,
+                            chrome,
                             "Audio packets",
                             format!("{}", self.audio_frames),
                         );
@@ -1286,6 +1300,67 @@ impl MonitorApp {
                     });
             });
     }
+}
+
+fn paint_gear(painter: &egui::Painter, center: Pos2, size: f32, color: Color32) {
+    let stroke_w = (size * 0.12).clamp(1.4, 2.2);
+    let r_ring = size * 0.28;
+    painter.circle_stroke(center, r_ring, egui::Stroke::new(stroke_w, color));
+    let tooth_inner = r_ring + stroke_w * 0.3;
+    let tooth_outer = size * 0.46;
+    for i in 0..8 {
+        let a = i as f32 * std::f32::consts::TAU / 8.0;
+        let (sin, cos) = a.sin_cos();
+        let dir = Vec2::new(cos, sin);
+        painter.line_segment(
+            [center + dir * tooth_inner, center + dir * tooth_outer],
+            egui::Stroke::new(stroke_w * 1.15, color),
+        );
+    }
+}
+
+fn prefs_button(ui: &mut Ui, chrome: UiChrome, label: &str, active: bool) -> bool {
+    let height = 36.0;
+    let (rect, resp) =
+        ui.allocate_exact_size(Vec2::new(ui.available_width(), height), Sense::click());
+    let hovered = resp.hovered();
+    let fill = if active {
+        chrome.accent_soft
+    } else if hovered {
+        chrome.surface_active
+    } else {
+        chrome.surface
+    };
+    let stroke = if active { chrome.accent } else { chrome.border };
+    let text_color = if active { chrome.accent } else { chrome.text };
+    let icon_color = if active || hovered {
+        chrome.accent
+    } else {
+        chrome.text_muted
+    };
+
+    ui.painter().rect_filled(rect, 6.0, fill);
+    ui.painter().rect_stroke(
+        rect,
+        6.0,
+        egui::Stroke::new(1.0, stroke),
+        egui::StrokeKind::Inside,
+    );
+
+    let icon_center = Pos2::new(rect.min.x + 18.0, rect.center().y);
+    paint_gear(ui.painter(), icon_center, 18.0, icon_color);
+    ui.painter().text(
+        Pos2::new(rect.min.x + 34.0, rect.center().y),
+        egui::Align2::LEFT_CENTER,
+        label,
+        egui::FontId::proportional(13.0),
+        text_color,
+    );
+
+    if hovered {
+        ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
+    }
+    resp.clicked()
 }
 
 fn chip(ui: &mut Ui, chrome: UiChrome, label: &str, active: bool) -> bool {

--- a/apps/studio-monitor/src/preferences.rs
+++ b/apps/studio-monitor/src/preferences.rs
@@ -78,6 +78,7 @@ pub fn show(
     settings: &MonitorSettings,
     audio_devices: &[AudioOutputDevice],
     selected_audio: Option<&str>,
+    audio_unavailable: bool,
     buffer: BufferSettings,
     video_delay_ms: u32,
     audio_delay_ms: u32,
@@ -261,6 +262,18 @@ pub fn show(
                                     }
                                 });
                         });
+                    if audio_unavailable {
+                        ui.add_space(6.0);
+                        ui.label(
+                            RichText::new(t(language, "monitor.audio_unavailable"))
+                                .color(chrome.text),
+                        );
+                        ui.label(
+                            RichText::new(t(language, "monitor.audio_unavailable_hint"))
+                                .small()
+                                .color(chrome.text_muted),
+                        );
+                    }
 
                     // —— A/V buffer (text fields) ——
                     ui.add_space(12.0);

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -1955,10 +1955,12 @@ fn name_field(
     } else {
         name.to_string()
     };
+    // Keep truncation on the inner text so the clickable box stays full-width.
     div()
         .flex()
         .flex_col()
         .gap_1()
+        .w_full()
         .min_w_0()
         .child(
             div()
@@ -1969,6 +1971,7 @@ fn name_field(
         .child(
             div()
                 .id("source-name")
+                .w_full()
                 .px_2()
                 .py_1()
                 .rounded_md()
@@ -1982,14 +1985,21 @@ fn name_field(
                 .opacity(if locked { 0.55 } else { 1.0 })
                 .cursor_text()
                 .text_xs()
-                .min_w_0()
-                .truncate()
-                .child(display)
                 .on_click(cx.listener(move |this, _, window, cx| {
                     if !locked {
                         this.begin_edit_name(window, cx);
                     }
-                })),
+                }))
+                .child(if editing {
+                    div().w_full().child(display).into_any_element()
+                } else {
+                    div()
+                        .w_full()
+                        .min_w_0()
+                        .truncate()
+                        .child(display)
+                        .into_any_element()
+                }),
         )
 }
 

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -1955,7 +1955,7 @@ fn name_field(
     } else {
         name.to_string()
     };
-    // Keep truncation on the inner text so the clickable box stays full-width.
+    // Avoid `.truncate()`: without a definite width it replaces the name with an ellipsis.
     div()
         .flex()
         .flex_col()
@@ -1985,21 +1985,12 @@ fn name_field(
                 .opacity(if locked { 0.55 } else { 1.0 })
                 .cursor_text()
                 .text_xs()
+                .child(display)
                 .on_click(cx.listener(move |this, _, window, cx| {
                     if !locked {
                         this.begin_edit_name(window, cx);
                     }
-                }))
-                .child(if editing {
-                    div().w_full().child(display).into_any_element()
-                } else {
-                    div()
-                        .w_full()
-                        .min_w_0()
-                        .truncate()
-                        .child(display)
-                        .into_any_element()
-                }),
+                })),
         )
 }
 

--- a/apps/test-patterns/src/ui.rs
+++ b/apps/test-patterns/src/ui.rs
@@ -23,7 +23,7 @@ use parking_lot::Mutex;
 use pattern_generator::{PatternKind, fill_uyvy, scroll_uyvy, uyvy_from_image_path};
 use smallvec::smallvec;
 use suite_core::{
-    Language, SimdCapabilities, TestPatternsConfig, load_test_patterns_config,
+    Language, SimdCapabilities, TestPatternsConfig, TestPatternsQuality, load_test_patterns_config,
     reveal_in_file_manager, save_test_patterns_config, t,
 };
 
@@ -330,13 +330,20 @@ fn image_display_name(path: &Path) -> SharedString {
     )
 }
 
-fn persist_test_patterns_prefs(paths: &[PathBuf], frame_buffer_frames: u32) {
-    let cfg = TestPatternsConfig {
-        schema_version: 1,
-        custom_images: paths.to_vec(),
-        frame_buffer_frames: clamp_video_frame_buffer_frames(frame_buffer_frames) as u32,
-    };
-    let _ = save_test_patterns_config(&cfg);
+fn quality_from_config(quality: TestPatternsQuality) -> Quality {
+    match quality {
+        TestPatternsQuality::Low => Quality::Low,
+        TestPatternsQuality::Medium => Quality::Medium,
+        TestPatternsQuality::High => Quality::High,
+    }
+}
+
+fn quality_to_config(quality: Quality) -> TestPatternsQuality {
+    match quality {
+        Quality::Low => TestPatternsQuality::Low,
+        Quality::High => TestPatternsQuality::High,
+        Quality::Medium | Quality::Default => TestPatternsQuality::Medium,
+    }
 }
 
 pub fn run_gpui(title: String, language: Language) -> Result<()> {
@@ -411,10 +418,10 @@ impl PatternsView {
             .map(|kind| (kind, pattern_thumb(kind)))
             .collect();
 
-        let saved_cfg = load_test_patterns_config().unwrap_or_default();
+        let saved_cfg = load_test_patterns_config().unwrap_or_default().sanitized();
         let frame_buffer_frames =
             clamp_video_frame_buffer_frames(saved_cfg.frame_buffer_frames) as u32;
-        let saved = saved_cfg.custom_images;
+        let saved = saved_cfg.custom_images.clone();
         let saved_count = saved.len();
         let mut custom_images = Vec::new();
         let mut kept_paths = Vec::new();
@@ -426,26 +433,24 @@ impl PatternsView {
             kept_paths.push(path.clone());
             custom_images.push(CustomImage { path, thumb });
         }
-        if kept_paths.len() != saved_count {
-            persist_test_patterns_prefs(&kept_paths, frame_buffer_frames);
-        }
+        let pruned_images = kept_paths.len() != saved_count;
 
         let mut view = Self {
             language,
-            name: "Test Pattern".into(),
+            name: saved_cfg.name.clone(),
             kind: PatternKind::SmpteColorBars,
-            width: 1920,
-            height: 1080,
+            width: saved_cfg.width,
+            height: saved_cfg.height,
             frame_rate: FrameRate {
-                n: 30_000,
-                d: 1_001,
+                n: saved_cfg.fps_n,
+                d: saved_cfg.fps_d,
             },
-            quality: Quality::Medium,
-            animate: true,
-            anim_speed_h_pct: 100,
-            anim_speed_v_pct: 100,
-            tone_hz: 1000.0,
-            level_dbfs: -20.0,
+            quality: quality_from_config(saved_cfg.quality),
+            animate: saved_cfg.animate,
+            anim_speed_h_pct: saved_cfg.anim_speed_h_pct,
+            anim_speed_v_pct: saved_cfg.anim_speed_v_pct,
+            tone_hz: saved_cfg.tone_hz,
+            level_dbfs: saved_cfg.level_dbfs,
             sample_rate: 48_000,
             channels: 2,
             samples: 480,
@@ -455,9 +460,9 @@ impl PatternsView {
             session: None,
             live: Arc::new(Mutex::new(LivePattern::from_view(
                 PatternKind::SmpteColorBars,
-                true,
-                100,
-                100,
+                saved_cfg.animate,
+                saved_cfg.anim_speed_h_pct,
+                saved_cfg.anim_speed_v_pct,
                 None,
             ))),
             last_stats: SendStats::default(),
@@ -476,6 +481,9 @@ impl PatternsView {
             name_editing: false,
         };
         view.refresh_title();
+        if pruned_images {
+            view.persist_prefs();
+        }
         view.restart_session();
         view.refresh_preview(cx);
         view.schedule_tick(cx);
@@ -652,7 +660,7 @@ impl PatternsView {
             path,
             thumb: Some(thumb),
         });
-        self.persist_images();
+        self.persist_prefs();
         let index = self.custom_images.len() - 1;
         self.select_custom_image(index, cx);
     }
@@ -666,7 +674,7 @@ impl PatternsView {
         if let Some(thumb) = removed.thumb {
             cx.drop_image(thumb, None);
         }
-        self.persist_images();
+        self.persist_prefs();
 
         let was_selected =
             self.kind == PatternKind::Image && self.selected_custom.is_some_and(|i| i == index);
@@ -685,13 +693,28 @@ impl PatternsView {
         cx.notify();
     }
 
-    fn persist_images(&self) {
-        let paths: Vec<_> = self
-            .custom_images
-            .iter()
-            .map(|img| img.path.clone())
-            .collect();
-        persist_test_patterns_prefs(&paths, self.frame_buffer_frames);
+    fn persist_prefs(&self) {
+        let cfg = TestPatternsConfig {
+            schema_version: 1,
+            custom_images: self
+                .custom_images
+                .iter()
+                .map(|img| img.path.clone())
+                .collect(),
+            frame_buffer_frames: clamp_video_frame_buffer_frames(self.frame_buffer_frames) as u32,
+            name: self.name.clone(),
+            width: self.width,
+            height: self.height,
+            fps_n: self.frame_rate.n,
+            fps_d: self.frame_rate.d,
+            quality: quality_to_config(self.quality),
+            animate: self.animate,
+            anim_speed_h_pct: self.anim_speed_h_pct,
+            anim_speed_v_pct: self.anim_speed_v_pct,
+            tone_hz: self.tone_hz,
+            level_dbfs: self.level_dbfs,
+        };
+        let _ = save_test_patterns_config(&cfg.sanitized());
     }
 
     fn nudge_frame_buffer(&mut self, delta: i32, cx: &mut Context<Self>) {
@@ -704,7 +727,7 @@ impl PatternsView {
             return;
         }
         self.frame_buffer_frames = next;
-        self.persist_images();
+        self.persist_prefs();
         if let Some(session) = self.session.as_ref() {
             session.set_frame_buffer_frames(next);
         }
@@ -742,6 +765,7 @@ impl PatternsView {
         if self.name.trim().is_empty() {
             self.name = "Test Pattern".into();
         }
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -764,6 +788,7 @@ impl PatternsView {
         let key = event.keystroke.key.as_str();
         if key == "backspace" {
             self.name.pop();
+            self.persist_prefs();
             cx.notify();
             return;
         }
@@ -776,6 +801,7 @@ impl PatternsView {
             && self.name.len() + ch.len() <= 64
         {
             self.name.push_str(ch);
+            self.persist_prefs();
             cx.notify();
         }
     }
@@ -789,6 +815,7 @@ impl PatternsView {
         }
         self.tone_hz = hz;
         self.push_live_audio();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -803,6 +830,7 @@ impl PatternsView {
             return;
         }
         self.frame_rate = frame_rate;
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -819,6 +847,7 @@ impl PatternsView {
         self.width = resolution.width;
         self.height = resolution.height;
         self.refresh_title();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -836,6 +865,7 @@ impl PatternsView {
         }
         self.width = next;
         self.refresh_title();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -851,6 +881,7 @@ impl PatternsView {
         }
         self.height = next;
         self.refresh_title();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -862,6 +893,7 @@ impl PatternsView {
         }
         self.push_live_content(true);
         self.refresh_preview(cx);
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -873,6 +905,7 @@ impl PatternsView {
         }
         self.anim_speed_h_pct = next;
         self.push_live_speeds();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -884,6 +917,7 @@ impl PatternsView {
         }
         self.anim_speed_v_pct = next;
         self.push_live_speeds();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -896,6 +930,7 @@ impl PatternsView {
         }
         self.level_dbfs = dbfs;
         self.push_live_audio();
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -925,6 +960,7 @@ impl PatternsView {
         if let Some(session) = self.session.as_ref() {
             session.set_quality(quality);
         }
+        self.persist_prefs();
         cx.notify();
     }
 
@@ -935,6 +971,7 @@ impl PatternsView {
         if self.name.trim().is_empty() {
             self.name = "Test Pattern".into();
         }
+        self.persist_prefs();
         self.restart_session();
         cx.notify();
     }

--- a/crates/omt-media/src/audio_out.rs
+++ b/crates/omt-media/src/audio_out.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, Ordering};
 use std::sync::mpsc::{self, Sender};
 use std::thread;
+use std::time::{Duration, Instant};
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{SampleFormat, StreamConfig};
@@ -13,6 +14,8 @@ use tracing::warn;
 
 const RING_CAP_SAMPLES: usize = 48_000 * 2 * 2; // ~2s stereo @ 48 kHz
 const TICKS_PER_SECOND: i64 = 10_000_000;
+/// If a stream is open but the callback never consumes PCM, mute after this.
+const DEAD_OUTPUT_GRACE: Duration = Duration::from_millis(500);
 
 /// Peak levels for VU display (linear 0..1, per channel).
 #[derive(Debug, Clone, Copy, Default)]
@@ -27,6 +30,17 @@ pub struct AudioLevels {
     pub sample_rate: i32,
     /// Declared channel count of the last packet.
     pub channels: i32,
+}
+
+/// Whether system audio playback is currently usable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioOutputStatus {
+    /// Output device is being opened.
+    Opening,
+    /// Device stream is running.
+    Ready,
+    /// No usable device; PCM is discarded and video stays on wall clock.
+    Unavailable,
 }
 
 /// A selectable system audio output device.
@@ -90,6 +104,14 @@ struct Shared {
     /// PTS currently being output (valid when `playhead_valid`).
     playhead_pts: AtomicI64,
     playhead_valid: AtomicBool,
+    /// Last time the device callback consumed queued PCM.
+    last_playback_activity: Mutex<Option<Instant>>,
+    status: Mutex<AudioOutputStatus>,
+    /// Fast path for [`AudioOutput::push_planar_f32`].
+    output_enabled: AtomicBool,
+    /// At least one packet was queued after the current stream opened.
+    queued_since_open: AtomicBool,
+    stream_opened_at: Mutex<Option<Instant>>,
 }
 
 enum AudioCmd {
@@ -127,6 +149,11 @@ impl AudioOutput {
             device_name: Mutex::new(None),
             playhead_pts: AtomicI64::new(0),
             playhead_valid: AtomicBool::new(false),
+            last_playback_activity: Mutex::new(None),
+            status: Mutex::new(AudioOutputStatus::Opening),
+            output_enabled: AtomicBool::new(false),
+            queued_since_open: AtomicBool::new(false),
+            stream_opened_at: Mutex::new(None),
         });
 
         let (cmd_tx, cmd_rx) = mpsc::channel();
@@ -140,6 +167,7 @@ impl AudioOutput {
             })
         {
             warn!("failed to spawn audio output thread: {e}");
+            apply_status(&shared, AudioOutputStatus::Unavailable);
             return Self {
                 shared,
                 cmd_tx: Mutex::new(None),
@@ -157,12 +185,20 @@ impl AudioOutput {
         self.shared.device_name.lock().clone()
     }
 
+    /// Snapshot of whether PCM is actually being sent to a device.
+    pub fn status(&self) -> AudioOutputStatus {
+        *self.shared.status.lock()
+    }
+
     /// Switch output device. `None` selects the system default.
     pub fn set_output_device(&self, name: Option<String>) {
         *self.shared.device_name.lock() = name.clone();
         self.clear();
         if let Some(tx) = self.cmd_tx.lock().as_ref() {
+            apply_status(&self.shared, AudioOutputStatus::Opening);
             let _ = tx.send(AudioCmd::SetDevice(name));
+        } else {
+            apply_status(&self.shared, AudioOutputStatus::Unavailable);
         }
     }
 
@@ -183,6 +219,14 @@ impl AudioOutput {
         } else {
             None
         }
+    }
+
+    /// Whether the output callback has recently consumed queued PCM.
+    pub(crate) fn playback_active(&self) -> bool {
+        self.shared
+            .last_playback_activity
+            .lock()
+            .is_some_and(|at| at.elapsed() <= Duration::from_millis(250))
     }
 
     /// Buffered audio duration currently sitting in the device ring (milliseconds).
@@ -206,6 +250,7 @@ impl AudioOutput {
         self.shared.ring.lock().clear();
         self.shared.pts_runs.lock().clear();
         *self.shared.levels.lock() = AudioLevels::default();
+        *self.shared.last_playback_activity.lock() = None;
         self.invalidate_playhead();
     }
 
@@ -213,6 +258,7 @@ impl AudioOutput {
     pub fn invalidate_playhead(&self) {
         self.shared.playhead_valid.store(false, Ordering::Release);
         self.shared.playhead_pts.store(0, Ordering::Release);
+        *self.shared.last_playback_activity.lock() = None;
     }
 
     /// Push planar f32 PCM (`ch0[samples]…chN[samples]` tightly packed as LE bytes).
@@ -230,6 +276,11 @@ impl AudioOutput {
         let n = samples.max(0) as usize;
         let expected = ch * n * 4;
         if n == 0 || data.len() < expected {
+            return;
+        }
+
+        if self.should_discard_pcm() {
+            self.record_silent_packet(sample_rate, channels);
             return;
         }
 
@@ -325,7 +376,48 @@ impl AudioOutput {
                 self.shared.playhead_pts.store(timestamp, Ordering::Release);
                 self.shared.playhead_valid.store(true, Ordering::Release);
             }
+            self.shared.queued_since_open.store(true, Ordering::Release);
         }
+    }
+
+    fn should_discard_pcm(&self) -> bool {
+        self.maybe_declare_dead_output();
+        !self.shared.output_enabled.load(Ordering::Acquire)
+    }
+
+    fn maybe_declare_dead_output(&self) {
+        if !self.shared.output_enabled.load(Ordering::Acquire) {
+            return;
+        }
+        if self.playback_active() {
+            return;
+        }
+        if !self.shared.queued_since_open.load(Ordering::Acquire) {
+            return;
+        }
+        let Some(opened_at) = *self.shared.stream_opened_at.lock() else {
+            return;
+        };
+        if opened_at.elapsed() <= DEAD_OUTPUT_GRACE {
+            return;
+        }
+        warn!("audio output opened but is not consuming PCM; muting");
+        apply_status(&self.shared, AudioOutputStatus::Unavailable);
+        self.shared.ring.lock().clear();
+        self.shared.pts_runs.lock().clear();
+        self.invalidate_playhead();
+        let mut levels = self.shared.levels.lock();
+        levels.peak_l = 0.0;
+        levels.peak_r = 0.0;
+    }
+
+    fn record_silent_packet(&self, sample_rate: i32, channels: i32) {
+        let mut levels = self.shared.levels.lock();
+        levels.peak_l = 0.0;
+        levels.peak_r = 0.0;
+        levels.frames = levels.frames.saturating_add(1);
+        levels.sample_rate = sample_rate;
+        levels.channels = channels;
     }
 }
 
@@ -365,6 +457,27 @@ fn db_to_gain(db: i32) -> f32 {
     10f32.powf(db as f32 / 20.0)
 }
 
+fn apply_status(shared: &Shared, status: AudioOutputStatus) {
+    *shared.status.lock() = status;
+    let ready = matches!(status, AudioOutputStatus::Ready);
+    shared.output_enabled.store(ready, Ordering::Release);
+    if ready {
+        *shared.stream_opened_at.lock() = Some(Instant::now());
+        shared.queued_since_open.store(false, Ordering::Release);
+    } else {
+        *shared.stream_opened_at.lock() = None;
+        shared.queued_since_open.store(false, Ordering::Release);
+        shared.output_enabled.store(false, Ordering::Release);
+    }
+}
+
+fn wait_device_cmd(cmd_rx: &mpsc::Receiver<AudioCmd>) -> Option<Option<String>> {
+    match cmd_rx.recv() {
+        Ok(AudioCmd::SetDevice(name)) => Some(name),
+        Ok(AudioCmd::Shutdown) | Err(_) => None,
+    }
+}
+
 fn resolve_device(name: &Option<String>) -> Result<cpal::Device, String> {
     let host = cpal::default_host();
     if let Some(want) = name {
@@ -383,18 +496,19 @@ fn resolve_device(name: &Option<String>) -> Result<cpal::Device, String> {
 fn run_output_thread(shared: Arc<Shared>, cmd_rx: mpsc::Receiver<AudioCmd>) -> Result<(), String> {
     let mut selected = shared.device_name.lock().clone();
     loop {
+        apply_status(&shared, AudioOutputStatus::Opening);
         let device = match resolve_device(&selected) {
             Ok(d) => d,
             Err(e) => {
                 warn!("audio output unavailable: {e}");
-                // Wait for a device change / shutdown instead of exiting permanently.
-                match cmd_rx.recv() {
-                    Ok(AudioCmd::SetDevice(name)) => {
+                apply_status(&shared, AudioOutputStatus::Unavailable);
+                match wait_device_cmd(&cmd_rx) {
+                    Some(name) => {
                         selected = name;
                         *shared.device_name.lock() = selected.clone();
                         continue;
                     }
-                    Ok(AudioCmd::Shutdown) | Err(_) => return Ok(()),
+                    None => return Ok(()),
                 }
             }
         };
@@ -403,13 +517,14 @@ fn run_output_thread(shared: Arc<Shared>, cmd_rx: mpsc::Receiver<AudioCmd>) -> R
             Ok(c) => c,
             Err(e) => {
                 warn!("audio output config failed: {e}");
-                match cmd_rx.recv() {
-                    Ok(AudioCmd::SetDevice(name)) => {
+                apply_status(&shared, AudioOutputStatus::Unavailable);
+                match wait_device_cmd(&cmd_rx) {
+                    Some(name) => {
                         selected = name;
                         *shared.device_name.lock() = selected.clone();
                         continue;
                     }
-                    Ok(AudioCmd::Shutdown) | Err(_) => return Ok(()),
+                    None => return Ok(()),
                 }
             }
         };
@@ -423,6 +538,7 @@ fn run_output_thread(shared: Arc<Shared>, cmd_rx: mpsc::Receiver<AudioCmd>) -> R
         shared.ring.lock().clear();
         shared.pts_runs.lock().clear();
         shared.playhead_valid.store(false, Ordering::Release);
+        *shared.last_playback_activity.lock() = None;
 
         let shared_cb = Arc::clone(&shared);
         let stream = match sample_format {
@@ -431,13 +547,14 @@ fn run_output_thread(shared: Arc<Shared>, cmd_rx: mpsc::Receiver<AudioCmd>) -> R
             SampleFormat::U16 => build_stream::<u16>(&device, &config, shared_cb),
             other => {
                 warn!("unsupported sample format: {other:?}");
-                match cmd_rx.recv() {
-                    Ok(AudioCmd::SetDevice(name)) => {
+                apply_status(&shared, AudioOutputStatus::Unavailable);
+                match wait_device_cmd(&cmd_rx) {
+                    Some(name) => {
                         selected = name;
                         *shared.device_name.lock() = selected.clone();
                         continue;
                     }
-                    Ok(AudioCmd::Shutdown) | Err(_) => return Ok(()),
+                    None => return Ok(()),
                 }
             }
         };
@@ -445,28 +562,41 @@ fn run_output_thread(shared: Arc<Shared>, cmd_rx: mpsc::Receiver<AudioCmd>) -> R
             Ok(s) => s,
             Err(e) => {
                 warn!("audio stream build failed: {e}");
-                match cmd_rx.recv() {
-                    Ok(AudioCmd::SetDevice(name)) => {
+                apply_status(&shared, AudioOutputStatus::Unavailable);
+                match wait_device_cmd(&cmd_rx) {
+                    Some(name) => {
                         selected = name;
                         *shared.device_name.lock() = selected.clone();
                         continue;
                     }
-                    Ok(AudioCmd::Shutdown) | Err(_) => return Ok(()),
+                    None => return Ok(()),
                 }
             }
         };
         if let Err(e) = stream.play() {
             warn!("audio stream play failed: {e}");
+            drop(stream);
+            apply_status(&shared, AudioOutputStatus::Unavailable);
+            match wait_device_cmd(&cmd_rx) {
+                Some(name) => {
+                    selected = name;
+                    *shared.device_name.lock() = selected.clone();
+                    continue;
+                }
+                None => return Ok(()),
+            }
         }
+        apply_status(&shared, AudioOutputStatus::Ready);
 
-        match cmd_rx.recv() {
-            Ok(AudioCmd::SetDevice(name)) => {
+        match wait_device_cmd(&cmd_rx) {
+            Some(name) => {
                 drop(stream);
                 selected = name;
                 *shared.device_name.lock() = selected.clone();
             }
-            Ok(AudioCmd::Shutdown) | Err(_) => {
+            None => {
                 drop(stream);
+                apply_status(&shared, AudioOutputStatus::Unavailable);
                 return Ok(());
             }
         }
@@ -482,6 +612,7 @@ where
     T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
 {
     let channels = config.channels.max(1) as usize;
+    let err_shared = Arc::clone(&shared);
     device
         .build_output_stream(
             *config,
@@ -505,10 +636,84 @@ where
                 if frames_from_ring > 0 {
                     let mut runs = shared.pts_runs.lock();
                     consume_pts_frames(&mut runs, frames_from_ring, &shared);
+                    *shared.last_playback_activity.lock() = Some(Instant::now());
                 }
             },
-            |err| warn!("audio stream error: {err}"),
+            move |err| {
+                warn!("audio stream error: {err}");
+                apply_status(&err_shared, AudioOutputStatus::Unavailable);
+            },
             None,
         )
         .map_err(|e| e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stub(status: AudioOutputStatus) -> AudioOutput {
+        let ready = matches!(status, AudioOutputStatus::Ready);
+        let shared = Arc::new(Shared {
+            ring: Mutex::new(VecDeque::with_capacity(8192)),
+            pts_runs: Mutex::new(VecDeque::new()),
+            levels: Mutex::new(AudioLevels::default()),
+            boost_db: AtomicI32::new(0),
+            geometry: Mutex::new(DeviceGeometry {
+                channels: 2,
+                rate: 48_000,
+            }),
+            device_name: Mutex::new(None),
+            playhead_pts: AtomicI64::new(0),
+            playhead_valid: AtomicBool::new(false),
+            last_playback_activity: Mutex::new(None),
+            status: Mutex::new(status),
+            output_enabled: AtomicBool::new(ready),
+            queued_since_open: AtomicBool::new(false),
+            stream_opened_at: Mutex::new(ready.then(Instant::now)),
+        });
+        AudioOutput {
+            shared,
+            cmd_tx: Mutex::new(None),
+        }
+    }
+
+    fn loud_packet() -> Vec<u8> {
+        let sample = 0.75f32.to_le_bytes();
+        let mut data = Vec::with_capacity(8);
+        data.extend_from_slice(&sample);
+        data.extend_from_slice(&sample);
+        data
+    }
+
+    #[test]
+    fn unavailable_output_discards_pcm_and_vu() {
+        let audio = stub(AudioOutputStatus::Unavailable);
+        audio.push_planar_f32(&loud_packet(), 1, 1, 48_000, 10_000);
+        let levels = audio.levels();
+        assert_eq!(levels.frames, 1);
+        assert_eq!(levels.peak_l, 0.0);
+        assert_eq!(levels.peak_r, 0.0);
+        assert!(audio.playhead_pts().is_none());
+        assert_eq!(audio.buffered_ms(), 0.0);
+        assert_eq!(audio.status(), AudioOutputStatus::Unavailable);
+    }
+
+    #[test]
+    fn idle_ready_stream_mutes_after_grace() {
+        let audio = stub(AudioOutputStatus::Ready);
+        *audio.shared.stream_opened_at.lock() =
+            Some(Instant::now() - DEAD_OUTPUT_GRACE - Duration::from_millis(50));
+        audio.push_planar_f32(&loud_packet(), 1, 1, 48_000, 10_000);
+        assert!(audio.buffered_ms() > 0.0);
+        assert_eq!(audio.status(), AudioOutputStatus::Ready);
+
+        audio.push_planar_f32(&loud_packet(), 1, 1, 48_000, 20_000);
+        assert_eq!(audio.status(), AudioOutputStatus::Unavailable);
+        assert_eq!(audio.buffered_ms(), 0.0);
+        assert!(audio.playhead_pts().is_none());
+        let levels = audio.levels();
+        assert_eq!(levels.peak_l, 0.0);
+        assert_eq!(levels.frames, 2);
+    }
 }

--- a/crates/omt-media/src/lib.rs
+++ b/crates/omt-media/src/lib.rs
@@ -12,7 +12,9 @@ mod send;
 mod stall;
 mod stats;
 
-pub use audio_out::{AudioLevels, AudioOutput, AudioOutputDevice, list_output_devices};
+pub use audio_out::{
+    AudioLevels, AudioOutput, AudioOutputDevice, AudioOutputStatus, list_output_devices,
+};
 pub use color::{rgb_to_uyvy_pixel, uyvy_from_rgb_frame};
 pub use discovery::{DiscoveredSource, SourceBrowser, discover_sources, spawn_discover};
 pub use playout::{BufferSettings, BufferUnit, DelaySetting};

--- a/crates/omt-media/src/playout.rs
+++ b/crates/omt-media/src/playout.rs
@@ -364,7 +364,12 @@ impl Playout {
 
     /// Nudge wall skew so the audio ring stays near the configured delay depth.
     fn steer_clock_to_audio_ring(&mut self, audio: &AudioOutput) {
-        if audio.playhead_pts().is_none() {
+        // Merely queueing PCM creates a playhead PTS. Only steer while the
+        // device callback is actually consuming samples; otherwise a missing
+        // or stalled output device winds the shared A/V clock backwards and
+        // freezes video after the initial buffered frames.
+        if !audio.playback_active() {
+            self.clock_skew_ticks = 0;
             return;
         }
         let target_ms = (self.audio_delay_ms() as f64).max(40.0);

--- a/crates/omt-media/tests/studio_monitor_soak.rs
+++ b/crates/omt-media/tests/studio_monitor_soak.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use omt_media::{ReceiveWorker, SendSession, SendSessionConfig, SessionState};
+
+#[test]
+fn studio_monitor_playout_keeps_advancing() {
+    let width = 640i32;
+    let height = 360i32;
+    let stride = width as usize * 2;
+    let pixels = Arc::new(vec![128u8; stride * height as usize]);
+    let provider_pixels = Arc::clone(&pixels);
+    let provider = Arc::new(move |_idx| provider_pixels.as_ref().clone());
+
+    let sender = SendSession::start(
+        SendSessionConfig {
+            name: "Studio Monitor Soak".into(),
+            width,
+            height,
+            fps_n: 30,
+            fps_d: 1,
+            ..SendSessionConfig::default()
+        },
+        provider,
+    )
+    .expect("start sender");
+    let port = sender.stats().port;
+    assert!(port > 0);
+
+    let worker = ReceiveWorker::spawn();
+    worker.connect(format!("omt://127.0.0.1:{port}"));
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut samples = Vec::new();
+    let mut last_sample = Instant::now() - Duration::from_secs(1);
+    while Instant::now() < deadline {
+        if last_sample.elapsed() >= Duration::from_secs(1) {
+            let latest = worker.latest();
+            let counters = *latest.counters.lock();
+            let stats = *latest.stats.lock();
+            let state = *latest.session_state.lock();
+            samples.push((
+                counters.frames_decoded,
+                counters.audio_frames,
+                stats.frames_decoded,
+                stats.bytes_received,
+                state,
+            ));
+            last_sample = Instant::now();
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    worker.shutdown();
+    drop(sender);
+
+    eprintln!("Studio Monitor playout samples: {samples:?}");
+    let first = samples
+        .iter()
+        .position(|s| s.0 > 0)
+        .expect("no presented video");
+    let final_sample = samples.last().expect("samples");
+    assert_eq!(final_sample.4, SessionState::Connected);
+    assert!(
+        final_sample.0 > samples[first].0 + 30,
+        "presented video stopped advancing: {samples:?}"
+    );
+    assert!(
+        final_sample.2 > samples[first].2 + 30,
+        "decoded video stopped advancing: {samples:?}"
+    );
+}

--- a/crates/suite-core/src/config.rs
+++ b/crates/suite-core/src/config.rs
@@ -46,8 +46,21 @@ impl Default for SuiteConfig {
     }
 }
 
+/// Encoding quality stored in Test Patterns preferences.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TestPatternsQuality {
+    /// Low quality.
+    Low,
+    /// Medium / standard quality.
+    #[default]
+    Medium,
+    /// High quality.
+    High,
+}
+
 /// Test Patterns tool preferences (`test-patterns.json`).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct TestPatternsConfig {
     /// Schema version.
@@ -56,6 +69,28 @@ pub struct TestPatternsConfig {
     pub custom_images: Vec<PathBuf>,
     /// Prefetched video frames for paced OMT send (1..=16, default 3).
     pub frame_buffer_frames: u32,
+    /// Discoverable OMT source name.
+    pub name: String,
+    /// Output width in pixels.
+    pub width: i32,
+    /// Output height in pixels.
+    pub height: i32,
+    /// Frame rate numerator.
+    pub fps_n: i32,
+    /// Frame rate denominator.
+    pub fps_d: i32,
+    /// Encoding quality.
+    pub quality: TestPatternsQuality,
+    /// Whether pattern / image scroll animation is enabled.
+    pub animate: bool,
+    /// Horizontal scroll speed percent (−200..=200).
+    pub anim_speed_h_pct: i32,
+    /// Vertical scroll speed percent (−200..=200).
+    pub anim_speed_v_pct: i32,
+    /// Tone frequency in Hz; `0` means mute.
+    pub tone_hz: f32,
+    /// Tone peak level in dBFS.
+    pub level_dbfs: f32,
 }
 
 impl Default for TestPatternsConfig {
@@ -64,7 +99,47 @@ impl Default for TestPatternsConfig {
             schema_version: 1,
             custom_images: Vec::new(),
             frame_buffer_frames: 3,
+            name: "Test Pattern".into(),
+            width: 1920,
+            height: 1080,
+            fps_n: 30_000,
+            fps_d: 1_001,
+            quality: TestPatternsQuality::Medium,
+            animate: true,
+            anim_speed_h_pct: 100,
+            anim_speed_v_pct: 100,
+            tone_hz: 1000.0,
+            level_dbfs: -20.0,
         }
+    }
+}
+
+impl TestPatternsConfig {
+    /// Clamp user-facing values into ranges the Test Patterns UI accepts.
+    pub fn sanitized(mut self) -> Self {
+        let trimmed = self.name.trim();
+        self.name = if trimmed.is_empty() {
+            "Test Pattern".into()
+        } else {
+            let mut name = trimmed.to_string();
+            while name.len() > 64 {
+                name.pop();
+            }
+            name
+        };
+        let width = self.width.clamp(64, 7680);
+        self.width = width - (width % 2);
+        self.height = self.height.clamp(64, 4320);
+        self.fps_n = self.fps_n.max(1);
+        self.fps_d = self.fps_d.max(1);
+        self.frame_buffer_frames = self.frame_buffer_frames.clamp(1, 16);
+        self.anim_speed_h_pct = self.anim_speed_h_pct.clamp(-200, 200);
+        self.anim_speed_v_pct = self.anim_speed_v_pct.clamp(-200, 200);
+        if self.tone_hz < 0.0 {
+            self.tone_hz = 0.0;
+        }
+        self.level_dbfs = self.level_dbfs.clamp(-120.0, 0.0);
+        self
     }
 }
 
@@ -185,22 +260,83 @@ mod tests {
     #[test]
     fn roundtrip_custom_images() {
         let cfg = TestPatternsConfig {
-            schema_version: 1,
             custom_images: vec![PathBuf::from("C:/images/bars.png")],
             frame_buffer_frames: 5,
+            name: "Cam A".into(),
+            width: 1280,
+            height: 720,
+            fps_n: 60,
+            fps_d: 1,
+            quality: TestPatternsQuality::High,
+            animate: false,
+            anim_speed_h_pct: 50,
+            anim_speed_v_pct: -20,
+            tone_hz: 440.0,
+            level_dbfs: -6.0,
+            ..Default::default()
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let parsed: TestPatternsConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.custom_images.len(), 1);
         assert_eq!(parsed.custom_images[0], PathBuf::from("C:/images/bars.png"));
         assert_eq!(parsed.frame_buffer_frames, 5);
+        assert_eq!(parsed.name, "Cam A");
+        assert_eq!(parsed.width, 1280);
+        assert_eq!(parsed.height, 720);
+        assert_eq!(parsed.fps_n, 60);
+        assert_eq!(parsed.fps_d, 1);
+        assert_eq!(parsed.quality, TestPatternsQuality::High);
+        assert!(!parsed.animate);
+        assert_eq!(parsed.anim_speed_h_pct, 50);
+        assert_eq!(parsed.anim_speed_v_pct, -20);
+        assert!((parsed.tone_hz - 440.0).abs() < f32::EPSILON);
+        assert!((parsed.level_dbfs + 6.0).abs() < f32::EPSILON);
     }
 
     #[test]
-    fn legacy_test_patterns_json_defaults_frame_buffer() {
+    fn legacy_test_patterns_json_defaults_new_fields() {
         let parsed: TestPatternsConfig =
             serde_json::from_str(r#"{"schema_version":1,"custom_images":[]}"#).unwrap();
         assert_eq!(parsed.frame_buffer_frames, 3);
+        assert_eq!(parsed.name, "Test Pattern");
+        assert_eq!(parsed.width, 1920);
+        assert_eq!(parsed.height, 1080);
+        assert_eq!(parsed.fps_n, 30_000);
+        assert_eq!(parsed.fps_d, 1_001);
+        assert_eq!(parsed.quality, TestPatternsQuality::Medium);
+        assert!(parsed.animate);
+        assert_eq!(parsed.anim_speed_h_pct, 100);
+        assert_eq!(parsed.anim_speed_v_pct, 100);
+        assert!((parsed.tone_hz - 1000.0).abs() < f32::EPSILON);
+        assert!((parsed.level_dbfs + 20.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn sanitizes_out_of_range_test_patterns_values() {
+        let parsed = TestPatternsConfig {
+            name: "  ".into(),
+            width: 1921,
+            height: 10,
+            fps_n: 0,
+            fps_d: 0,
+            anim_speed_h_pct: 999,
+            anim_speed_v_pct: -999,
+            tone_hz: -1.0,
+            level_dbfs: 12.0,
+            frame_buffer_frames: 99,
+            ..Default::default()
+        }
+        .sanitized();
+        assert_eq!(parsed.name, "Test Pattern");
+        assert_eq!(parsed.width, 1920);
+        assert_eq!(parsed.height, 64);
+        assert_eq!(parsed.fps_n, 1);
+        assert_eq!(parsed.fps_d, 1);
+        assert_eq!(parsed.anim_speed_h_pct, 200);
+        assert_eq!(parsed.anim_speed_v_pct, -200);
+        assert!((parsed.tone_hz - 0.0).abs() < f32::EPSILON);
+        assert!((parsed.level_dbfs - 0.0).abs() < f32::EPSILON);
+        assert_eq!(parsed.frame_buffer_frames, 16);
     }
 
     #[test]

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -171,6 +171,14 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::Japanese, "monitor.audio_system_default") => "既定",
         (Language::English, "monitor.audio_none") => "No output devices found",
         (Language::Japanese, "monitor.audio_none") => "出力デバイスが見つかりません",
+        (Language::English, "monitor.audio_unavailable") => "No audio output",
+        (Language::Japanese, "monitor.audio_unavailable") => "音声出力なし",
+        (Language::English, "monitor.audio_unavailable_hint") => {
+            "Video continues. Choose another output device in Settings."
+        }
+        (Language::Japanese, "monitor.audio_unavailable_hint") => {
+            "映像は再生を続けます。設定から別の出力デバイスを選んでください。"
+        }
         (Language::English, "monitor.av_buffer") => "A/V buffer",
         (Language::Japanese, "monitor.av_buffer") => "A/Vバッファ",
         (Language::English, "monitor.buffer_video") => "Video delay",

--- a/crates/suite-core/src/lib.rs
+++ b/crates/suite-core/src/lib.rs
@@ -11,10 +11,10 @@ mod theme;
 mod version;
 
 pub use config::{
-    LauncherConfig, StudioMonitorConfig, SuiteConfig, TestPatternsConfig, app_config_path,
-    config_dir, config_path, load_config, load_launcher_config, load_studio_monitor_config,
-    load_test_patterns_config, save_config, save_launcher_config, save_studio_monitor_config,
-    save_test_patterns_config,
+    LauncherConfig, StudioMonitorConfig, SuiteConfig, TestPatternsConfig, TestPatternsQuality,
+    app_config_path, config_dir, config_path, load_config, load_launcher_config,
+    load_studio_monitor_config, load_test_patterns_config, save_config, save_launcher_config,
+    save_studio_monitor_config, save_test_patterns_config,
 };
 #[cfg(feature = "egui-fonts")]
 pub use fonts::install_egui_cjk_fonts;


### PR DESCRIPTION
## Summary
- The source name field collapsed to an ellipsis after the overflow layout change, so it could not be clicked or edited even after stopping OMT send.
- Keep the field full-width and stop truncating it to `...`, including while send is locked.
- Persist source name, scroll speed, and footer settings in `test-patterns.json` so they restore on launch.

## Test plan
- [x] Open Test Patterns, stop sending, and confirm the source name shows the actual name (not `...`)
- [x] Click the source name field and confirm it enters edit mode
- [x] Start sending and confirm the field stays locked but still shows the real source name (not `...`)
- [x] Stop sending again and confirm the name can be edited
- [x] Change source name, H/V scroll speed, Animate, resolution, framerate, quality, tone, level, and frame buffer; quit and relaunch; confirm those values are restored
- [x] Resize the window narrower and confirm the source name field remains visible and clickable when idle

Closes #39