### PR TITLE
Write tool logs to the official OMT logs directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,8 +1219,7 @@ dependencies = [
  "anyhow",
  "clap",
  "omt-media",
- "tracing",
- "tracing-subscriber",
+ "suite-core",
 ]
 
 [[package]]
@@ -6103,8 +6102,6 @@ dependencies = [
  "omt-media",
  "parking_lot",
  "suite-core",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -6122,8 +6119,6 @@ dependencies = [
  "rfd",
  "smallvec",
  "suite-core",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -8419,6 +8414,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ egui = "0.36"
 arc-swap = "1.7"
 parking_lot = "0.12"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 clap = { version = "4", features = ["derive"] }
 cpal = "0.18"

--- a/apps/studio-monitor/Cargo.toml
+++ b/apps/studio-monitor/Cargo.toml
@@ -20,5 +20,3 @@ egui.workspace = true
 omt-media.workspace = true
 parking_lot.workspace = true
 suite-core = { workspace = true, features = ["egui-fonts"] }
-tracing.workspace = true
-tracing-subscriber.workspace = true

--- a/apps/studio-monitor/src/main.rs
+++ b/apps/studio-monitor/src/main.rs
@@ -10,7 +10,7 @@ mod preferences;
 mod settings;
 
 use clap::Parser;
-use suite_core::{LaunchOverrides, t};
+use suite_core::{LaunchOverrides, init_tracing, t};
 
 #[derive(Debug, Parser)]
 #[command(name = "omt-studio-monitor", about = "OMT Studio Monitor")]
@@ -27,9 +27,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    init_tracing();
 
     let args = Args::parse();
     let overrides = LaunchOverrides::resolve(

--- a/apps/test-patterns/Cargo.toml
+++ b/apps/test-patterns/Cargo.toml
@@ -23,5 +23,3 @@ pattern-generator.workspace = true
 rfd = "0.15"
 smallvec = "1"
 suite-core.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true

--- a/apps/test-patterns/src/main.rs
+++ b/apps/test-patterns/src/main.rs
@@ -6,7 +6,7 @@
 mod ui;
 
 use clap::Parser;
-use suite_core::{LaunchOverrides, t};
+use suite_core::{LaunchOverrides, init_tracing, t};
 
 #[derive(Debug, Parser)]
 #[command(name = "omt-test-patterns", about = "OMT Test Patterns")]
@@ -20,9 +20,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    init_tracing();
 
     let args = Args::parse();
     let overrides = LaunchOverrides::resolve(

--- a/crates/capture-spike/Cargo.toml
+++ b/crates/capture-spike/Cargo.toml
@@ -15,5 +15,4 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 omt-media.workspace = true
-tracing.workspace = true
-tracing-subscriber.workspace = true
+suite-core.workspace = true

--- a/crates/capture-spike/src/main.rs
+++ b/crates/capture-spike/src/main.rs
@@ -4,6 +4,7 @@ mod capture;
 
 use capture::CaptureProbe;
 use clap::Parser;
+use suite_core::init_tracing;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -17,9 +18,7 @@ struct Args {
 }
 
 fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .init();
+    init_tracing();
 
     let args = Args::parse();
     let probe = CaptureProbe::detect()?;

--- a/crates/suite-core/Cargo.toml
+++ b/crates/suite-core/Cargo.toml
@@ -14,6 +14,8 @@ egui = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 default = []

--- a/crates/suite-core/src/lib.rs
+++ b/crates/suite-core/src/lib.rs
@@ -5,6 +5,7 @@
 mod config;
 mod fonts;
 mod i18n;
+mod logging;
 mod reveal;
 mod simd;
 mod theme;
@@ -20,6 +21,7 @@ pub use config::{
 pub use fonts::install_egui_cjk_fonts;
 pub use fonts::load_cjk_font_bytes;
 pub use i18n::{Language, t};
+pub use logging::init_tracing;
 pub use reveal::{RevealError, reveal_in_file_manager};
 pub use simd::SimdCapabilities;
 pub use theme::ThemePreference;

--- a/crates/suite-core/src/logging.rs
+++ b/crates/suite-core/src/logging.rs
@@ -1,0 +1,298 @@
+//! libomtnet-compatible file logging and tracing setup.
+
+use std::fmt::{self, Write as FmtWrite};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use tracing::Event;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+
+/// Environment variable overriding the OMT storage directory.
+pub const OMT_STORAGE_PATH: &str = "OMT_STORAGE_PATH";
+
+static LOG_FILE: OnceLock<Mutex<Option<File>>> = OnceLock::new();
+
+/// Directory that contains `settings.xml` and `logs/`.
+pub fn storage_dir() -> PathBuf {
+    storage_dir_from(
+        std::env::var(OMT_STORAGE_PATH)
+            .ok()
+            .filter(|s| !s.is_empty()),
+        std::env::var_os("ProgramData").map(PathBuf::from),
+        std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(PathBuf::from),
+    )
+}
+
+fn storage_dir_from(
+    storage_override: Option<String>,
+    program_data: Option<PathBuf>,
+    home: Option<PathBuf>,
+) -> PathBuf {
+    if let Some(p) = storage_override {
+        return PathBuf::from(p);
+    }
+    default_storage_dir(program_data, home)
+}
+
+fn default_storage_dir(program_data: Option<PathBuf>, home: Option<PathBuf>) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let _ = home;
+        program_data
+            .unwrap_or_else(|| PathBuf::from(r"C:\ProgramData"))
+            .join("OMT")
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = program_data;
+        home.unwrap_or_else(|| PathBuf::from(".")).join(".OMT")
+    }
+}
+
+/// `{storage}/logs`.
+pub fn logs_dir() -> PathBuf {
+    storage_dir().join("logs")
+}
+
+/// `{exe_name}{pid}.log` under [`logs_dir`], matching libomtnet `OMTLogging`.
+pub fn default_log_path() -> PathBuf {
+    log_path_in(&logs_dir())
+}
+
+fn log_path_in(dir: &Path) -> PathBuf {
+    dir.join(format!("{}.log", process_name_and_id()))
+}
+
+fn process_name_and_id() -> String {
+    let pid = std::process::id();
+    match std::env::current_exe() {
+        Ok(exe) => match exe.file_name() {
+            Some(name) => format!("{}{pid}", name.to_string_lossy()),
+            None => pid.to_string(),
+        },
+        Err(_) => pid.to_string(),
+    }
+}
+
+fn open_append(path: &Path) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    OpenOptions::new().create(true).append(true).open(path)
+}
+
+fn ensure_file() -> &'static Mutex<Option<File>> {
+    LOG_FILE.get_or_init(|| match open_append(&default_log_path()) {
+        Ok(mut file) => {
+            let _ = writeln!(file, "{},[OMTLogging],Log Started", timestamp());
+            let _ = file.flush();
+            Mutex::new(Some(file))
+        }
+        Err(_) => Mutex::new(None),
+    })
+}
+
+/// Append a libomtnet-style line: `{datetime},[{source}],{message}`.
+fn write_line(message: &str, source: &str) {
+    let line = format!("{},[{}],{message}", timestamp(), source);
+    let Ok(mut guard) = ensure_file().lock() else {
+        return;
+    };
+    if let Some(file) = guard.as_mut() {
+        let _ = writeln!(file, "{line}");
+        let _ = file.flush();
+    }
+}
+
+/// Initialize tracing to stderr (`RUST_LOG`) and the official OMT log file.
+///
+/// Safe to call more than once; later calls are ignored if a subscriber is
+/// already installed.
+pub fn init_tracing() {
+    let _ = ensure_file();
+    let env_filter = EnvFilter::from_default_env();
+    let _ = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(OmtFileLayer)
+        .try_init();
+}
+
+struct OmtFileLayer;
+
+impl<S> Layer<S> for OmtFileLayer
+where
+    S: tracing::Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut message = String::new();
+        event.record(&mut MessageVisitor(&mut message));
+        if message.is_empty() {
+            message.push_str(event.metadata().name());
+        }
+        write_line(&message, event.metadata().target());
+    }
+}
+
+struct MessageVisitor<'a>(&'a mut String);
+
+impl Visit for MessageVisitor<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        if !self.0.is_empty() {
+            self.0.push(' ');
+        }
+        if field.name() == "message" {
+            let _ = write!(self.0, "{value:?}");
+        } else {
+            let _ = write!(self.0, "{}={value:?}", field.name());
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if !self.0.is_empty() {
+            self.0.push(' ');
+        }
+        if field.name() == "message" {
+            self.0.push_str(value);
+        } else {
+            self.0.push_str(field.name());
+            self.0.push('=');
+            self.0.push_str(value);
+        }
+    }
+}
+
+fn timestamp() -> String {
+    #[cfg(windows)]
+    {
+        #[repr(C)]
+        struct SystemTime {
+            w_year: u16,
+            w_month: u16,
+            w_day_of_week: u16,
+            w_day: u16,
+            w_hour: u16,
+            w_minute: u16,
+            w_second: u16,
+            w_milliseconds: u16,
+        }
+        unsafe extern "system" {
+            fn GetLocalTime(lp_system_time: *mut SystemTime);
+        }
+        let mut st = SystemTime {
+            w_year: 0,
+            w_month: 0,
+            w_day_of_week: 0,
+            w_day: 0,
+            w_hour: 0,
+            w_minute: 0,
+            w_second: 0,
+            w_milliseconds: 0,
+        };
+        unsafe { GetLocalTime(&mut st) };
+        format!(
+            "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+            st.w_year, st.w_month, st.w_day, st.w_hour, st.w_minute, st.w_second
+        )
+    }
+    #[cfg(unix)]
+    {
+        #[repr(C)]
+        struct Tm {
+            tm_sec: i32,
+            tm_min: i32,
+            tm_hour: i32,
+            tm_mday: i32,
+            tm_mon: i32,
+            tm_year: i32,
+            tm_wday: i32,
+            tm_yday: i32,
+            tm_isdst: i32,
+            _pad: [u8; 32],
+        }
+        unsafe extern "C" {
+            fn time(tloc: *mut i64) -> i64;
+            fn localtime_r(timep: *const i64, result: *mut Tm) -> *mut Tm;
+        }
+        unsafe {
+            let mut t: i64 = 0;
+            time(&mut t);
+            let mut tm = Tm {
+                tm_sec: 0,
+                tm_min: 0,
+                tm_hour: 0,
+                tm_mday: 0,
+                tm_mon: 0,
+                tm_year: 0,
+                tm_wday: 0,
+                tm_yday: 0,
+                tm_isdst: 0,
+                _pad: [0; 32],
+            };
+            if localtime_r(&t, &mut tm).is_null() {
+                return format!("{t}");
+            }
+            format!(
+                "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+                tm.tm_year + 1900,
+                tm.tm_mon + 1,
+                tm.tm_mday,
+                tm.tm_hour,
+                tm.tm_min,
+                tm.tm_sec
+            )
+        }
+    }
+    #[cfg(not(any(windows, unix)))]
+    {
+        String::from("unknown-time")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn storage_override_wins() {
+        let dir = storage_dir_from(
+            Some(String::from("/tmp/omt-store")),
+            Some(PathBuf::from(r"C:\ProgramData")),
+            Some(PathBuf::from("/home/user")),
+        );
+        assert_eq!(dir, PathBuf::from("/tmp/omt-store"));
+    }
+
+    #[test]
+    fn default_storage_dir_is_platform_specific() {
+        let dir = default_storage_dir(
+            Some(PathBuf::from(r"C:\ProgramData")),
+            Some(PathBuf::from("/home/user")),
+        );
+        #[cfg(windows)]
+        {
+            assert_eq!(dir, PathBuf::from(r"C:\ProgramData\OMT"));
+        }
+        #[cfg(not(windows))]
+        {
+            assert_eq!(dir, PathBuf::from("/home/user/.OMT"));
+        }
+    }
+
+    #[test]
+    fn log_filename_is_module_name_plus_pid() {
+        let path = log_path_in(Path::new("/tmp/logs"));
+        let name = path.file_name().unwrap().to_string_lossy();
+        assert!(
+            name.ends_with(&format!("{}.log", std::process::id())),
+            "expected libomtnet ModuleName+pid.log, got {name}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Tee Studio Monitor, Test Patterns, and capture-spike tracing to the official OMT log file.
- Windows: `%ProgramData%\OMT\logs`; macOS/Linux: `~/.OMT/logs`; override with `OMT_STORAGE_PATH`.
- Shared helper lives in `suite-core::init_tracing` so stderr/`RUST_LOG` behavior is unchanged.

## Test plan
- [ ] `cargo test -p suite-core --lib logging`
- [ ] Launch Studio Monitor and confirm `omt-studio-monitor.exe{pid}.log` under `C:\ProgramData\OMT\logs` (or `~/.OMT/logs`)
- [ ] Confirm console/`RUST_LOG` output still works in debug builds
- [ ] Confirm existing PR #43 is unaffected (this branch is from `main`)