### PR TITLE
Bundle Config Manager and Discovery Server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,9 @@ jobs:
             libxcb-shape0-dev \
             libxcb-xfixes0-dev
       - name: Clippy (workspace libs/tools)
-        run: cargo clippy -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike -p omt-studio-monitor -p omt-test-patterns --all-targets -- -D warnings
+        run: cargo clippy -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server --all-targets -- -D warnings
       - name: Test
-        run: cargo test -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike
+        run: cargo test -p suite-core -p omt-media -p pattern-generator -p monitor-bench -p capture-spike -p omt-config-manager -p omt-discovery-server
 
   build-tools:
     strategy:
@@ -72,7 +72,7 @@ jobs:
           toolchain: "1.97"
           targets: ${{ matrix.target }}
       - name: Build release tools
-        run: cargo build --release --target ${{ matrix.target }} -p omt-studio-monitor -p omt-test-patterns -p capture-spike
+        run: cargo build --release --target ${{ matrix.target }} -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server -p capture-spike
       - name: Upload tool artifacts
         uses: actions/upload-artifact@v6
         with:
@@ -80,6 +80,8 @@ jobs:
           path: |
             target/${{ matrix.target }}/release/omt-studio-monitor*
             target/${{ matrix.target }}/release/omt-test-patterns*
+            target/${{ matrix.target }}/release/omt-config-manager*
+            target/${{ matrix.target }}/release/omt-discovery-server*
             target/${{ matrix.target }}/release/omt-screen-capture-spike*
 
   build-windows-arm64:
@@ -92,7 +94,7 @@ jobs:
           toolchain: "1.97"
           targets: aarch64-pc-windows-msvc
       - name: Build Windows Arm64 tools
-        run: cargo build --release --target aarch64-pc-windows-msvc -p omt-studio-monitor -p omt-test-patterns -p capture-spike
+        run: cargo build --release --target aarch64-pc-windows-msvc -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server -p capture-spike
       - name: Upload tool artifacts
         if: success()
         uses: actions/upload-artifact@v6
@@ -101,6 +103,8 @@ jobs:
           path: |
             target/aarch64-pc-windows-msvc/release/omt-studio-monitor*
             target/aarch64-pc-windows-msvc/release/omt-test-patterns*
+            target/aarch64-pc-windows-msvc/release/omt-config-manager*
+            target/aarch64-pc-windows-msvc/release/omt-discovery-server*
             target/aarch64-pc-windows-msvc/release/omt-screen-capture-spike*
 
   launcher-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
             libasound2-dev \
             libudev-dev \
             libxkbcommon-dev \
+            libxkbcommon-x11-dev \
             libwayland-dev \
             libxcb-render0-dev \
             libxcb-shape0-dev \

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -42,7 +42,7 @@ jobs:
           bun-version: '1.2.19'
 
       - name: Build sidecar tools
-        run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
+        run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server
 
       - name: Prepare sidecars (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           bun-version: '1.2.19'
 
       - name: Build sidecar tools
-        run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
+        run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server
 
       - name: Prepare sidecars (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -46,7 +46,7 @@ jobs:
         run: ./scripts/ci/prefetch-nsis.ps1
 
       - name: Build sidecar tools
-        run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns
+        run: cargo build --release --target ${{ matrix.rust_target }} -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server
 
       - name: Prepare sidecars (Windows)
         if: runner.os == 'Windows'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6091,6 +6091,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "gpui",
+ "if-addrs",
  "openmediatransport",
  "suite-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -2004,6 +2004,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix 0.31.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2914,7 +2925,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
- "roxmltree",
+ "roxmltree 0.20.0",
 ]
 
 [[package]]
@@ -5208,7 +5219,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6062,6 +6073,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "omt-config-manager"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "gpui",
+ "openmediatransport",
+ "suite-core",
+]
+
+[[package]]
+name = "omt-discovery-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "ctrlc",
+ "gpui",
+ "openmediatransport",
+ "suite-core",
+]
+
+[[package]]
 name = "omt-launcher"
 version = "0.1.0"
 dependencies = [
@@ -6182,10 +6216,11 @@ dependencies = [
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs#55ffd08ab899f8017056886157fb0d130ab36d5c"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=221f3e2f200f754dbfbe63997c75e2e90d3bc47d#221f3e2f200f754dbfbe63997c75e2e90d3bc47d"
 dependencies = [
  "bytes",
  "mdns-sd",
+ "roxmltree 0.21.1",
  "socket2",
  "thiserror 2.0.20",
  "tokio",
@@ -7337,6 +7372,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8192,7 +8236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8286,7 +8330,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9548,7 +9592,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9607,7 +9651,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9786,7 +9830,7 @@ dependencies = [
  "kurbo 0.11.3",
  "log",
  "pico-args",
- "roxmltree",
+ "roxmltree 0.20.0",
  "rustybuzz 0.20.1",
  "simplecss",
  "siphasher",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "crates/capture-spike",
     "apps/studio-monitor",
     "apps/test-patterns",
+    "apps/config-manager",
+    "apps/discovery-server",
     "apps/launcher/src-tauri",
 ]
 default-members = [
@@ -17,6 +19,8 @@ default-members = [
     "crates/monitor-bench",
     "apps/studio-monitor",
     "apps/test-patterns",
+    "apps/config-manager",
+    "apps/discovery-server",
 ]
 
 [workspace.package]
@@ -31,7 +35,7 @@ suite-core = { path = "crates/suite-core" }
 omt-media = { path = "crates/omt-media" }
 pattern-generator = { path = "crates/pattern-generator" }
 monitor-bench = { path = "crates/monitor-bench" }
-openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", features = ["tokio"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "221f3e2f200f754dbfbe63997c75e2e90d3bc47d", features = ["tokio"] }
 gpui = "0.2.2"
 vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs" }
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Open Media Transport production utilities inspired by NDI Tools.
 
 | Tool | Description |
 |------|-------------|
-| Studio Monitor |  Discover and view OMT sources on the LAN |
-| Test Patterns |  Send SMPTE-style patterns + tone over OMT |
-| Screen Capture |  Windows Graphics Capture / ScreenCaptureKit (WIP) |
+| Studio Monitor | Discover and view OMT sources on the LAN |
+| Test Patterns | Send SMPTE-style patterns + tone over OMT |
+| Config Manager | View and edit the global OMT `settings.xml` |
+| Discovery Server | GUI + CLI TCP discovery server (port 6399) |
+| Screen Capture | Windows Graphics Capture / ScreenCaptureKit (WIP) |
 
 Runtime media stack: [`MikanseiLaboratory/openmediatransport-rs`](https://github.com/MikanseiLaboratory/openmediatransport-rs) + [`MikanseiLaboratory/vmx-rs`](https://github.com/MikanseiLaboratory/vmx-rs)
 (VMX SIMD path reporting via `simd_path()`: `avx2` / `sse128` / `neon` / `scalar`).

--- a/apps/config-manager/Cargo.toml
+++ b/apps/config-manager/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "omt-config-manager"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "OMT Config Manager — edit settings.xml (GPUI)"
+
+[[bin]]
+name = "omt-config-manager"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+gpui.workspace = true
+openmediatransport.workspace = true
+suite-core.workspace = true

--- a/apps/config-manager/src/main.rs
+++ b/apps/config-manager/src/main.rs
@@ -1,0 +1,34 @@
+//! OMT Config Manager (GPUI).
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod model;
+mod ui;
+
+use clap::Parser;
+use suite_core::{LaunchOverrides, init_tracing, t};
+
+#[derive(Debug, Parser)]
+#[command(name = "omt-config-manager", about = "OMT Config Manager")]
+struct Args {
+    /// UI language (`en` / `ja`).
+    #[arg(long)]
+    language: Option<String>,
+    /// Theme (`light` / `dark` / `system`).
+    #[arg(long)]
+    theme: Option<String>,
+}
+
+fn main() -> anyhow::Result<()> {
+    init_tracing();
+
+    let args = Args::parse();
+    let overrides = LaunchOverrides::resolve(
+        args.language.as_deref().and_then(|s| s.parse().ok()),
+        args.theme.as_deref().and_then(|s| s.parse().ok()),
+        None,
+    );
+
+    let title = t(overrides.language, "tool.config_manager").to_string();
+    ui::run_gpui(title, overrides.language)
+}

--- a/apps/config-manager/src/model.rs
+++ b/apps/config-manager/src/model.rs
@@ -1,0 +1,344 @@
+//! In-memory editor for libomtnet-compatible `settings.xml`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use openmediatransport::{
+    KEY_DISCOVERY_SERVER, KEY_NETWORK_PORT_END, KEY_NETWORK_PORT_START, NETWORK_PORT_END,
+    NETWORK_PORT_START, Settings, settings_file_path,
+};
+
+const KNOWN_KEYS: [&str; 3] = [
+    KEY_DISCOVERY_SERVER,
+    KEY_NETWORK_PORT_START,
+    KEY_NETWORK_PORT_END,
+];
+
+/// Editable view of a `settings.xml` file.
+#[derive(Debug, Clone)]
+pub struct SettingsEditor {
+    /// Absolute path of the XML file.
+    pub path: PathBuf,
+    /// `DiscoveryServer` value (`omt://host:port` or empty for DNS-SD).
+    pub discovery_server: String,
+    /// `NetworkPortStart` as edited text.
+    pub port_start: String,
+    /// `NetworkPortEnd` as edited text.
+    pub port_end: String,
+    /// Unknown / extra keys, in sorted order.
+    pub extras: Vec<(String, String)>,
+    /// Draft key for the add-row form.
+    pub new_key: String,
+    /// Draft value for the add-row form.
+    pub new_value: String,
+    /// Last success message.
+    pub status: Option<String>,
+    /// Last error / validation message. Save is blocked while unreadable.
+    pub error: Option<String>,
+    /// True when the on-disk file could not be read.
+    pub unreadable: bool,
+}
+
+impl SettingsEditor {
+    /// Load the process-wide settings file.
+    pub fn load() -> Self {
+        Self::load_from_path(settings_file_path())
+    }
+
+    /// Load `path` without writing it.
+    pub fn load_from_path(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let mut editor = Self {
+            path: path.clone(),
+            discovery_server: String::new(),
+            port_start: NETWORK_PORT_START.to_string(),
+            port_end: NETWORK_PORT_END.to_string(),
+            extras: Vec::new(),
+            new_key: String::new(),
+            new_value: String::new(),
+            status: None,
+            error: None,
+            unreadable: false,
+        };
+        editor.reload_from(&path);
+        editor
+    }
+
+    /// Re-read the current path from disk.
+    pub fn reload(&mut self) {
+        let path = self.path.clone();
+        self.reload_from(&path);
+        if self.error.is_none() {
+            self.status = Some("Reloaded".into());
+        }
+    }
+
+    fn reload_from(&mut self, path: &Path) {
+        self.status = None;
+        self.error = None;
+        self.unreadable = false;
+        if path.exists() {
+            match fs::read_to_string(path) {
+                Ok(_) => {}
+                Err(e) => {
+                    self.unreadable = true;
+                    self.error = Some(format!("could not read {}: {e}", path.display()));
+                    return;
+                }
+            }
+        }
+        let settings = Settings::from_path(path);
+        self.discovery_server = settings.get_string(KEY_DISCOVERY_SERVER, "");
+        let (start, end) = settings.network_port_range();
+        self.port_start = start.to_string();
+        self.port_end = end.to_string();
+        self.extras = settings
+            .to_vec()
+            .into_iter()
+            .filter(|(k, _)| !KNOWN_KEYS.contains(&k.as_str()))
+            .collect();
+    }
+
+    /// Validate fields without writing.
+    pub fn validate(&self) -> Result<(), String> {
+        if self.unreadable {
+            return Err("file could not be read; fix permissions and reload before saving".into());
+        }
+        validate_discovery_url(&self.discovery_server)?;
+        let start = parse_port(&self.port_start, "Sender port start")?;
+        let end = parse_port(&self.port_end, "Sender port end")?;
+        if start > end {
+            return Err("Sender port start must be less than or equal to port end".into());
+        }
+        for (key, _) in &self.extras {
+            if !is_xml_name(key) {
+                return Err(format!("invalid extra key {key:?}"));
+            }
+            if KNOWN_KEYS.contains(&key.as_str()) {
+                return Err(format!(
+                    "{key} is a dedicated field; remove it from extra keys"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Persist the editor contents. Does not write when validation fails.
+    pub fn save(&mut self) -> Result<(), String> {
+        self.validate()?;
+        let mut settings = Settings::from_path(&self.path);
+        let desired: Vec<String> = std::iter::once(KEY_DISCOVERY_SERVER.to_string())
+            .chain([
+                KEY_NETWORK_PORT_START.to_string(),
+                KEY_NETWORK_PORT_END.to_string(),
+            ])
+            .chain(self.extras.iter().map(|(k, _)| k.clone()))
+            .collect();
+        for (key, _) in settings.to_vec() {
+            if !desired.iter().any(|k| k == &key) {
+                settings.remove(&key);
+            }
+        }
+        settings.set_string(KEY_DISCOVERY_SERVER, self.discovery_server.trim());
+        settings.set_integer(
+            KEY_NETWORK_PORT_START,
+            i32::from(parse_port(&self.port_start, "Sender port start")?),
+        );
+        settings.set_integer(
+            KEY_NETWORK_PORT_END,
+            i32::from(parse_port(&self.port_end, "Sender port end")?),
+        );
+        for (key, value) in &self.extras {
+            settings.set_string(key, value);
+        }
+        settings.save().map_err(|e| e.to_string())?;
+        self.error = None;
+        self.status = Some("Saved".into());
+        Ok(())
+    }
+
+    /// Clear DiscoveryServer so clients fall back to DNS-SD.
+    pub fn clear_discovery(&mut self) {
+        self.discovery_server.clear();
+        self.status = None;
+        self.error = None;
+    }
+
+    /// Append the draft extra key if it is a valid XML name.
+    pub fn add_extra(&mut self) -> Result<(), String> {
+        let key = self.new_key.trim().to_string();
+        if !is_xml_name(&key) {
+            return Err("key must be a valid XML name (letter or _ first)".into());
+        }
+        if KNOWN_KEYS.contains(&key.as_str()) || self.extras.iter().any(|(k, _)| k == &key) {
+            return Err(format!("{key} already exists"));
+        }
+        self.extras.push((key, self.new_value.clone()));
+        self.extras.sort_by(|a, b| a.0.cmp(&b.0));
+        self.new_key.clear();
+        self.new_value.clear();
+        self.error = None;
+        Ok(())
+    }
+
+    /// Remove an extra key by index.
+    pub fn remove_extra(&mut self, index: usize) {
+        if index < self.extras.len() {
+            self.extras.remove(index);
+        }
+    }
+}
+
+fn parse_port(raw: &str, label: &str) -> Result<u16, String> {
+    let value: u32 = raw
+        .trim()
+        .parse()
+        .map_err(|_| format!("{label} must be an integer from 1 to 65535"))?;
+    if (1..=65535).contains(&value) {
+        Ok(value as u16)
+    } else {
+        Err(format!("{label} must be an integer from 1 to 65535"))
+    }
+}
+
+fn validate_discovery_url(raw: &str) -> Result<(), String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(());
+    }
+    let rest = raw
+        .strip_prefix("omt://")
+        .ok_or_else(|| "Discovery Server must be empty (DNS-SD) or omt://host:port".to_string())?;
+    let rest = rest.split('/').next().unwrap_or(rest);
+    if rest.is_empty() {
+        return Err("Discovery Server host is missing".into());
+    }
+    if let Some((host, port)) = rest.rsplit_once(':') {
+        if host.is_empty() || host == "[" {
+            return Err("Discovery Server host is missing".into());
+        }
+        parse_port(port, "Discovery Server port")?;
+    }
+    Ok(())
+}
+
+fn is_xml_name(key: &str) -> bool {
+    let mut chars = key.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path() -> PathBuf {
+        let n = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("omt-cfg-{}-{n}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("settings.xml")
+    }
+
+    fn cleanup(path: &Path) {
+        let _ = fs::remove_file(path);
+        if let Some(dir) = path.parent() {
+            let _ = fs::remove_dir(dir);
+        }
+    }
+
+    #[test]
+    fn roundtrip_known_and_unknown_keys() {
+        let path = temp_path();
+        fs::write(
+            &path,
+            "<Settings>\n  <DiscoveryServer>omt://10.0.0.1:6399</DiscoveryServer>\n  <VendorKey>keep</VendorKey>\n</Settings>\n",
+        )
+        .unwrap();
+        let mut editor = SettingsEditor::load_from_path(&path);
+        assert_eq!(editor.discovery_server, "omt://10.0.0.1:6399");
+        assert_eq!(editor.extras, vec![("VendorKey".into(), "keep".into())]);
+        editor.discovery_server = "omt://127.0.0.1:6399".into();
+        editor.port_start = "6500".into();
+        editor.port_end = "6510".into();
+        editor.extras[0].1 = "updated".into();
+        editor.save().unwrap();
+
+        let loaded = Settings::from_path(&path);
+        assert_eq!(
+            loaded.get_string(KEY_DISCOVERY_SERVER, ""),
+            "omt://127.0.0.1:6399"
+        );
+        assert_eq!(loaded.get_integer(KEY_NETWORK_PORT_START, 0), 6500);
+        assert_eq!(loaded.get_integer(KEY_NETWORK_PORT_END, 0), 6510);
+        assert_eq!(loaded.get_string("VendorKey", ""), "updated");
+        cleanup(&path);
+    }
+
+    #[test]
+    fn rejects_invalid_url_and_inverted_ports_without_writing() {
+        let path = temp_path();
+        let mut editor = SettingsEditor::load_from_path(&path);
+        editor.discovery_server = "http://nope".into();
+        assert!(editor.save().is_err());
+        assert!(!path.exists());
+
+        editor.discovery_server = "omt://127.0.0.1:6399".into();
+        editor.port_start = "6600".into();
+        editor.port_end = "6400".into();
+        assert!(
+            editor
+                .validate()
+                .unwrap_err()
+                .contains("less than or equal")
+        );
+        assert!(!path.exists());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn remove_extra_key_is_persisted() {
+        let path = temp_path();
+        let mut editor = SettingsEditor::load_from_path(&path);
+        editor.new_key = "CustomFlag".into();
+        editor.new_value = "yes".into();
+        editor.add_extra().unwrap();
+        editor.save().unwrap();
+        assert!(fs::read_to_string(&path).unwrap().contains("CustomFlag"));
+
+        editor.remove_extra(0);
+        editor.save().unwrap();
+        let xml = fs::read_to_string(&path).unwrap();
+        assert!(!xml.contains("CustomFlag"));
+        cleanup(&path);
+    }
+
+    #[test]
+    fn empty_discovery_means_dns_sd() {
+        let path = temp_path();
+        let mut editor = SettingsEditor::load_from_path(&path);
+        editor.discovery_server = "omt://10.0.0.2:6399".into();
+        editor.save().unwrap();
+        editor.clear_discovery();
+        editor.save().unwrap();
+        let loaded = Settings::from_path(&path);
+        assert!(loaded.discovery_server().is_none());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn unreadable_file_does_not_save() {
+        let path = temp_path();
+        let mut editor = SettingsEditor::load_from_path(&path);
+        editor.unreadable = true;
+        editor.error = Some("denied".into());
+        assert!(editor.save().unwrap_err().contains("could not be read"));
+        cleanup(&path);
+    }
+}

--- a/apps/config-manager/src/model.rs
+++ b/apps/config-manager/src/model.rs
@@ -187,6 +187,49 @@ impl SettingsEditor {
             self.extras.remove(index);
         }
     }
+
+    /// XML that [`Self::save`] would write, from the current editor fields.
+    pub fn preview_xml(&self) -> String {
+        let mut values = std::collections::BTreeMap::new();
+        values.insert(
+            KEY_DISCOVERY_SERVER.to_string(),
+            self.discovery_server.trim().to_string(),
+        );
+        values.insert(
+            KEY_NETWORK_PORT_START.to_string(),
+            self.port_start.trim().to_string(),
+        );
+        values.insert(
+            KEY_NETWORK_PORT_END.to_string(),
+            self.port_end.trim().to_string(),
+        );
+        for (key, value) in &self.extras {
+            let key = key.trim();
+            if !key.is_empty() {
+                values.insert(key.to_string(), value.clone());
+            }
+        }
+        let mut out = String::from("<Settings>\n");
+        for (k, v) in values {
+            out.push_str("  <");
+            out.push_str(&k);
+            out.push('>');
+            out.push_str(&escape_xml(&v));
+            out.push_str("</");
+            out.push_str(&k);
+            out.push_str(">\n");
+        }
+        out.push_str("</Settings>\n");
+        out
+    }
+}
+
+fn escape_xml(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
 }
 
 fn parse_port(raw: &str, label: &str) -> Result<u16, String> {
@@ -329,6 +372,24 @@ mod tests {
         editor.save().unwrap();
         let loaded = Settings::from_path(&path);
         assert!(loaded.discovery_server().is_none());
+        cleanup(&path);
+    }
+
+    #[test]
+    fn preview_xml_follows_editor_fields() {
+        let path = temp_path();
+        let mut editor = SettingsEditor::load_from_path(&path);
+        editor.discovery_server.clear();
+        editor.port_start = "6400".into();
+        editor.port_end = "6600".into();
+        editor.new_key = "VendorKey".into();
+        editor.new_value = "keep".into();
+        editor.add_extra().unwrap();
+        let xml = editor.preview_xml();
+        assert!(xml.contains("<DiscoveryServer></DiscoveryServer>"));
+        assert!(xml.contains("<NetworkPortStart>6400</NetworkPortStart>"));
+        assert!(xml.contains("<NetworkPortEnd>6600</NetworkPortEnd>"));
+        assert!(xml.contains("<VendorKey>keep</VendorKey>"));
         cleanup(&path);
     }
 

--- a/apps/config-manager/src/ui.rs
+++ b/apps/config-manager/src/ui.rs
@@ -1,0 +1,459 @@
+//! GPUI Config Manager window.
+
+use anyhow::Result;
+use gpui::{
+    App, Application, Bounds, Context, FocusHandle, Focusable, Font, FontFallbacks, FontFeatures,
+    FontStyle, FontWeight, InteractiveElement, KeyDownEvent, SharedString, Window, WindowBounds,
+    WindowOptions, div, prelude::*, px, rgb, size,
+};
+use suite_core::{Language, reveal_in_file_manager, t};
+
+use crate::model::SettingsEditor;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EditTarget {
+    None,
+    Discovery,
+    PortStart,
+    PortEnd,
+    ExtraKey(usize),
+    ExtraValue(usize),
+    NewKey,
+    NewValue,
+}
+
+pub fn run_gpui(title: String, language: Language) -> Result<()> {
+    Application::new().run(move |cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(760.0), px(720.0)), cx);
+        let title = SharedString::from(title);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                titlebar: Some(gpui::TitlebarOptions {
+                    title: Some(title.clone()),
+                    ..Default::default()
+                }),
+                app_id: Some(suite_core::ToolId::ConfigManager.binary_name().into()),
+                ..Default::default()
+            },
+            move |_, cx| cx.new(|cx| ConfigView::new(cx, language)),
+        )
+        .expect("open GPUI Config Manager window");
+        cx.activate(true);
+    });
+    Ok(())
+}
+
+struct ConfigView {
+    language: Language,
+    editor: SettingsEditor,
+    editing: EditTarget,
+    focus_handle: FocusHandle,
+}
+
+impl ConfigView {
+    fn new(cx: &mut Context<Self>, language: Language) -> Self {
+        Self {
+            language,
+            editor: SettingsEditor::load(),
+            editing: EditTarget::None,
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    fn begin_edit(&mut self, target: EditTarget, window: &mut Window, cx: &mut Context<Self>) {
+        self.editing = target;
+        self.focus_handle.focus(window);
+        cx.notify();
+    }
+
+    fn apply_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        if self.editing == EditTarget::None {
+            return;
+        }
+        let key = event.keystroke.key.as_str();
+        if key == "escape" {
+            self.editing = EditTarget::None;
+            cx.notify();
+            return;
+        }
+        if key == "enter" {
+            self.editing = EditTarget::None;
+            cx.notify();
+            return;
+        }
+        let Some(field) = self.field_mut() else {
+            return;
+        };
+        if key == "backspace" {
+            field.pop();
+            cx.notify();
+            return;
+        }
+        if let Some(ch) = event.keystroke.key_char.as_deref()
+            && ch.chars().all(|c| !c.is_control())
+            && field.len() + ch.len() <= 256
+        {
+            field.push_str(ch);
+            cx.notify();
+        }
+    }
+
+    fn field_mut(&mut self) -> Option<&mut String> {
+        match self.editing {
+            EditTarget::None => None,
+            EditTarget::Discovery => Some(&mut self.editor.discovery_server),
+            EditTarget::PortStart => Some(&mut self.editor.port_start),
+            EditTarget::PortEnd => Some(&mut self.editor.port_end),
+            EditTarget::NewKey => Some(&mut self.editor.new_key),
+            EditTarget::NewValue => Some(&mut self.editor.new_value),
+            EditTarget::ExtraKey(i) => self.editor.extras.get_mut(i).map(|(k, _)| k),
+            EditTarget::ExtraValue(i) => self.editor.extras.get_mut(i).map(|(_, v)| v),
+        }
+    }
+
+    fn save(&mut self, cx: &mut Context<Self>) {
+        match self.editor.save() {
+            Ok(()) => {}
+            Err(e) => {
+                self.editor.status = None;
+                self.editor.error = Some(e);
+            }
+        }
+        cx.notify();
+    }
+
+    fn reload(&mut self, cx: &mut Context<Self>) {
+        self.editor.reload();
+        self.editing = EditTarget::None;
+        cx.notify();
+    }
+}
+
+impl Focusable for ConfigView {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for ConfigView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let lang = self.language;
+        let path = self.editor.path.display().to_string();
+        let can_save = !self.editor.unreadable;
+        let extras = self.editor.extras.clone();
+        let editing = self.editing;
+        let mut extra_rows = Vec::new();
+        for (i, (k, v)) in extras.iter().enumerate() {
+            extra_rows.push(extra_row(cx, lang, i, k, v, editing).into_any_element());
+        }
+
+        div()
+            .relative()
+            .flex()
+            .flex_col()
+            .size_full()
+            .font(ui_font())
+            .bg(rgb(0x1a1d23))
+            .text_color(rgb(0xedf2f7))
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                this.apply_key(event, cx);
+            }))
+            .child(
+                div()
+                    .px_4()
+                    .py_2()
+                    .border_b_1()
+                    .border_color(rgb(0x2a3340))
+                    .font_weight(FontWeight::BOLD)
+                    .child(t(lang, "tool.config_manager")),
+            )
+            .child(
+                div()
+                    .id("config-body")
+                    .flex()
+                    .flex_col()
+                    .gap_3()
+                    .p_4()
+                    .overflow_y_scroll()
+                    .flex_1()
+                    .child(label_row(t(lang, "config.path"), path.clone()))
+                    .child(
+                        div()
+                            .flex()
+                            .gap_2()
+                            .child(action_button(
+                                cx,
+                                "reload".into(),
+                                t(lang, "config.reload"),
+                                rgb(0x243041),
+                                |this, _, cx| this.reload(cx),
+                            ))
+                            .child(action_button(
+                                cx,
+                                "reveal".into(),
+                                t(lang, "config.reveal"),
+                                rgb(0x243041),
+                                move |this, _, cx| {
+                                    let _ = reveal_in_file_manager(&this.editor.path);
+                                    cx.notify();
+                                },
+                            ))
+                            .child(action_button(
+                                cx,
+                                "save".into(),
+                                t(lang, "save"),
+                                if can_save {
+                                    rgb(0x2f6fed)
+                                } else {
+                                    rgb(0x243041)
+                                },
+                                |this, _, cx| this.save(cx),
+                            )),
+                    )
+                    .child(status_line(&self.editor))
+                    .child(section(t(lang, "config.discovery")))
+                    .child(field(
+                        cx,
+                        "discovery".into(),
+                        t(lang, "config.discovery"),
+                        &self.editor.discovery_server,
+                        self.editing == EditTarget::Discovery,
+                        EditTarget::Discovery,
+                    ))
+                    .child(
+                        div()
+                            .text_xs()
+                            .opacity(0.65)
+                            .child(t(lang, "config.discovery_hint")),
+                    )
+                    .child(action_button(
+                        cx,
+                        "dns-sd".into(),
+                        t(lang, "config.clear_discovery"),
+                        rgb(0x243041),
+                        |this, _, cx| {
+                            this.editor.clear_discovery();
+                            cx.notify();
+                        },
+                    ))
+                    .child(section(t(lang, "config.port_start")))
+                    .child(
+                        div()
+                            .flex()
+                            .gap_3()
+                            .child(field(
+                                cx,
+                                "port-start".into(),
+                                t(lang, "config.port_start"),
+                                &self.editor.port_start,
+                                self.editing == EditTarget::PortStart,
+                                EditTarget::PortStart,
+                            ))
+                            .child(field(
+                                cx,
+                                "port-end".into(),
+                                t(lang, "config.port_end"),
+                                &self.editor.port_end,
+                                self.editing == EditTarget::PortEnd,
+                                EditTarget::PortEnd,
+                            )),
+                    )
+                    .child(section(t(lang, "config.extra")))
+                    .children(extra_rows)
+                    .child(
+                        div()
+                            .flex()
+                            .gap_2()
+                            .items_end()
+                            .child(field(
+                                cx,
+                                "new-key".into(),
+                                t(lang, "config.key"),
+                                &self.editor.new_key,
+                                self.editing == EditTarget::NewKey,
+                                EditTarget::NewKey,
+                            ))
+                            .child(field(
+                                cx,
+                                "new-value".into(),
+                                t(lang, "config.value"),
+                                &self.editor.new_value,
+                                self.editing == EditTarget::NewValue,
+                                EditTarget::NewValue,
+                            ))
+                            .child(action_button(
+                                cx,
+                                "add".into(),
+                                t(lang, "config.add"),
+                                rgb(0x243041),
+                                |this, _, cx| {
+                                    if let Err(e) = this.editor.add_extra() {
+                                        this.editor.error = Some(e);
+                                        this.editor.status = None;
+                                    }
+                                    cx.notify();
+                                },
+                            )),
+                    ),
+            )
+    }
+}
+
+fn extra_row(
+    cx: &mut Context<ConfigView>,
+    lang: Language,
+    index: usize,
+    key: &str,
+    value: &str,
+    editing: EditTarget,
+) -> impl IntoElement + use<> {
+    div()
+        .flex()
+        .gap_2()
+        .items_end()
+        .child(field(
+            cx,
+            SharedString::from(format!("ek-{index}")),
+            t(lang, "config.key"),
+            key,
+            editing == EditTarget::ExtraKey(index),
+            EditTarget::ExtraKey(index),
+        ))
+        .child(field(
+            cx,
+            SharedString::from(format!("ev-{index}")),
+            t(lang, "config.value"),
+            value,
+            editing == EditTarget::ExtraValue(index),
+            EditTarget::ExtraValue(index),
+        ))
+        .child(action_button(
+            cx,
+            SharedString::from(format!("del-{index}")),
+            t(lang, "config.delete"),
+            rgb(0xb33a3a),
+            move |this, _, cx| {
+                this.editor.remove_extra(index);
+                this.editing = EditTarget::None;
+                cx.notify();
+            },
+        ))
+}
+
+fn field(
+    cx: &mut Context<ConfigView>,
+    id: SharedString,
+    caption: &str,
+    value: &str,
+    editing: bool,
+    target: EditTarget,
+) -> impl IntoElement + use<> {
+    let display = if editing {
+        format!("{value}|")
+    } else {
+        value.to_string()
+    };
+    let caption = SharedString::from(caption.to_string());
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .flex_1()
+        .min_w_0()
+        .child(div().text_xs().opacity(0.65).child(caption))
+        .child(
+            div()
+                .id(id)
+                .w_full()
+                .px_2()
+                .py_1()
+                .rounded_md()
+                .border_1()
+                .border_color(if editing {
+                    rgb(0x2f6fed)
+                } else {
+                    rgb(0x2a3340)
+                })
+                .bg(rgb(0x0c1016))
+                .cursor_text()
+                .text_xs()
+                .child(display)
+                .on_click(cx.listener(move |this, _, window, cx| {
+                    this.begin_edit(target, window, cx);
+                })),
+        )
+}
+
+fn action_button<F>(
+    cx: &mut Context<ConfigView>,
+    id: SharedString,
+    label: &str,
+    color: gpui::Rgba,
+    on_click: F,
+) -> impl IntoElement + use<F>
+where
+    F: Fn(&mut ConfigView, &gpui::ClickEvent, &mut Context<ConfigView>) + 'static + Clone,
+{
+    let label = SharedString::from(label.to_string());
+    div()
+        .id(id)
+        .px_3()
+        .py_1()
+        .rounded_md()
+        .bg(color)
+        .cursor_pointer()
+        .text_xs()
+        .font_weight(FontWeight::SEMIBOLD)
+        .child(label)
+        .on_click(cx.listener(move |this, event, _, cx| on_click(this, event, cx)))
+}
+
+fn section(title: &str) -> impl IntoElement + use<> {
+    div()
+        .mt_2()
+        .font_weight(FontWeight::BOLD)
+        .child(SharedString::from(title.to_string()))
+}
+
+fn label_row(caption: &str, value: String) -> impl IntoElement + use<> {
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(div().text_xs().opacity(0.65).child(caption.to_string()))
+        .child(div().text_xs().child(value))
+}
+
+fn status_line(editor: &SettingsEditor) -> impl IntoElement + use<> {
+    if let Some(err) = &editor.error {
+        div().text_xs().text_color(rgb(0xff8a8a)).child(err.clone())
+    } else if let Some(ok) = &editor.status {
+        div().text_xs().text_color(rgb(0x8ad7a0)).child(ok.clone())
+    } else {
+        div()
+    }
+}
+
+fn ui_font() -> Font {
+    Font {
+        family: ".SystemUIFont".into(),
+        features: FontFeatures::default(),
+        fallbacks: Some(FontFallbacks::from_fonts(vec![
+            "Yu Gothic UI".into(),
+            "Yu Gothic".into(),
+            "Meiryo UI".into(),
+            "Meiryo".into(),
+            "MS UI Gothic".into(),
+            "Segoe UI".into(),
+            "Hiragino Sans".into(),
+            "Hiragino Kaku Gothic ProN".into(),
+            "Noto Sans CJK JP".into(),
+            "Noto Sans JP".into(),
+            "Source Han Sans JP".into(),
+        ])),
+        weight: FontWeight::default(),
+        style: FontStyle::default(),
+    }
+}

--- a/apps/config-manager/src/ui.rs
+++ b/apps/config-manager/src/ui.rs
@@ -24,7 +24,7 @@ enum EditTarget {
 
 pub fn run_gpui(title: String, language: Language) -> Result<()> {
     Application::new().run(move |cx: &mut App| {
-        let bounds = Bounds::centered(None, size(px(760.0), px(720.0)), cx);
+        let bounds = Bounds::centered(None, size(px(780.0), px(860.0)), cx);
         let title = SharedString::from(title);
         cx.open_window(
             WindowOptions {
@@ -114,7 +114,9 @@ impl ConfigView {
 
     fn save(&mut self, cx: &mut Context<Self>) {
         match self.editor.save() {
-            Ok(()) => {}
+            Ok(()) => {
+                self.editor.status = Some(t(self.language, "config.saved").to_string());
+            }
             Err(e) => {
                 self.editor.status = None;
                 self.editor.error = Some(e);
@@ -126,6 +128,27 @@ impl ConfigView {
     fn reload(&mut self, cx: &mut Context<Self>) {
         self.editor.reload();
         self.editing = EditTarget::None;
+        if self.editor.error.is_none() {
+            self.editor.status = Some(t(self.language, "config.reloaded").to_string());
+        }
+        cx.notify();
+    }
+
+    fn use_dns_sd(&mut self, cx: &mut Context<Self>) {
+        let already_empty = self.editor.discovery_server.trim().is_empty();
+        self.editor.clear_discovery();
+        self.editing = EditTarget::None;
+        self.editor.status = Some(
+            t(
+                self.language,
+                if already_empty {
+                    "config.dns_sd_already"
+                } else {
+                    "config.dns_sd_cleared"
+                },
+            )
+            .to_string(),
+        );
         cx.notify();
     }
 }
@@ -143,6 +166,8 @@ impl Render for ConfigView {
         let can_save = !self.editor.unreadable;
         let extras = self.editor.extras.clone();
         let editing = self.editing;
+        let dns_sd = self.editor.discovery_server.trim().is_empty();
+        let xml_preview = self.editor.preview_xml();
         let mut extra_rows = Vec::new();
         for (i, (k, v)) in extras.iter().enumerate() {
             extra_rows.push(extra_row(cx, lang, i, k, v, editing).into_any_element());
@@ -219,48 +244,91 @@ impl Render for ConfigView {
                         "discovery".into(),
                         t(lang, "config.discovery"),
                         &self.editor.discovery_server,
+                        t(lang, "config.ph_discovery"),
                         self.editing == EditTarget::Discovery,
                         EditTarget::Discovery,
                     ))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .px_2()
+                                    .py_1()
+                                    .rounded_md()
+                                    .bg(if dns_sd { rgb(0x1f3d2a) } else { rgb(0x243041) })
+                                    .text_xs()
+                                    .text_color(if dns_sd { rgb(0x8ad7a0) } else { rgb(0xedf2f7) })
+                                    .child(t(
+                                        lang,
+                                        if dns_sd {
+                                            "config.mode_dns_sd"
+                                        } else {
+                                            "config.mode_unicast"
+                                        },
+                                    )),
+                            )
+                            .child(action_button(
+                                cx,
+                                "dns-sd".into(),
+                                t(lang, "config.clear_discovery"),
+                                rgb(0x243041),
+                                |this, _, cx| this.use_dns_sd(cx),
+                            )),
+                    )
                     .child(
                         div()
                             .text_xs()
                             .opacity(0.65)
                             .child(t(lang, "config.discovery_hint")),
                     )
-                    .child(action_button(
-                        cx,
-                        "dns-sd".into(),
-                        t(lang, "config.clear_discovery"),
-                        rgb(0x243041),
-                        |this, _, cx| {
-                            this.editor.clear_discovery();
-                            cx.notify();
-                        },
-                    ))
-                    .child(section(t(lang, "config.port_start")))
+                    .child(section(t(lang, "config.port_range")))
                     .child(
                         div()
                             .flex()
-                            .gap_3()
+                            .items_end()
+                            .gap_2()
                             .child(field(
                                 cx,
                                 "port-start".into(),
                                 t(lang, "config.port_start"),
                                 &self.editor.port_start,
+                                t(lang, "config.ph_port_start"),
                                 self.editing == EditTarget::PortStart,
                                 EditTarget::PortStart,
                             ))
+                            .child(
+                                div()
+                                    .pb_1()
+                                    .text_sm()
+                                    .opacity(0.8)
+                                    .child(t(lang, "config.port_range_sep")),
+                            )
                             .child(field(
                                 cx,
                                 "port-end".into(),
                                 t(lang, "config.port_end"),
                                 &self.editor.port_end,
+                                t(lang, "config.ph_port_end"),
                                 self.editing == EditTarget::PortEnd,
                                 EditTarget::PortEnd,
                             )),
                     )
+                    .child(
+                        div()
+                            .text_xs()
+                            .opacity(0.65)
+                            .child(t(lang, "config.port_range_hint")),
+                    )
                     .child(section(t(lang, "config.extra")))
+                    .child(
+                        div()
+                            .text_xs()
+                            .opacity(0.65)
+                            .child(t(lang, "config.extra_hint")),
+                    )
                     .children(extra_rows)
                     .child(
                         div()
@@ -272,6 +340,7 @@ impl Render for ConfigView {
                                 "new-key".into(),
                                 t(lang, "config.key"),
                                 &self.editor.new_key,
+                                t(lang, "config.ph_key"),
                                 self.editing == EditTarget::NewKey,
                                 EditTarget::NewKey,
                             ))
@@ -280,6 +349,7 @@ impl Render for ConfigView {
                                 "new-value".into(),
                                 t(lang, "config.value"),
                                 &self.editor.new_value,
+                                t(lang, "config.ph_value"),
                                 self.editing == EditTarget::NewValue,
                                 EditTarget::NewValue,
                             ))
@@ -296,7 +366,15 @@ impl Render for ConfigView {
                                     cx.notify();
                                 },
                             )),
-                    ),
+                    )
+                    .child(section(t(lang, "config.xml_preview")))
+                    .child(
+                        div()
+                            .text_xs()
+                            .opacity(0.65)
+                            .child(t(lang, "config.xml_preview_hint")),
+                    )
+                    .child(xml_preview_box(&xml_preview)),
             )
     }
 }
@@ -318,6 +396,7 @@ fn extra_row(
             SharedString::from(format!("ek-{index}")),
             t(lang, "config.key"),
             key,
+            t(lang, "config.ph_key"),
             editing == EditTarget::ExtraKey(index),
             EditTarget::ExtraKey(index),
         ))
@@ -326,6 +405,7 @@ fn extra_row(
             SharedString::from(format!("ev-{index}")),
             t(lang, "config.value"),
             value,
+            t(lang, "config.ph_value"),
             editing == EditTarget::ExtraValue(index),
             EditTarget::ExtraValue(index),
         ))
@@ -347,13 +427,17 @@ fn field(
     id: SharedString,
     caption: &str,
     value: &str,
+    placeholder: &str,
     editing: bool,
     target: EditTarget,
 ) -> impl IntoElement + use<> {
-    let display = if editing {
-        format!("{value}|")
+    let empty = value.is_empty();
+    let (display, placeholder_shown) = if editing {
+        (format!("{value}|"), false)
+    } else if empty {
+        (placeholder.to_string(), true)
     } else {
-        value.to_string()
+        (value.to_string(), false)
     };
     let caption = SharedString::from(caption.to_string());
     div()
@@ -379,11 +463,42 @@ fn field(
                 .bg(rgb(0x0c1016))
                 .cursor_text()
                 .text_xs()
+                .text_color(if placeholder_shown {
+                    rgb(0x6a7380)
+                } else {
+                    rgb(0xedf2f7)
+                })
                 .child(display)
                 .on_click(cx.listener(move |this, _, window, cx| {
                     this.begin_edit(target, window, cx);
                 })),
         )
+}
+
+fn xml_preview_box(xml: &str) -> impl IntoElement + use<> {
+    div()
+        .id("xml-preview")
+        .flex()
+        .flex_col()
+        .gap_0()
+        .min_h(px(140.0))
+        .max_h(px(240.0))
+        .overflow_y_scroll()
+        .p_3()
+        .rounded_md()
+        .bg(rgb(0x0c1016))
+        .border_1()
+        .border_color(rgb(0x2a3340))
+        .font(mono_font())
+        .text_xs()
+        .text_color(rgb(0xb8c2cc))
+        .children(xml.lines().map(|line| {
+            div().child(if line.is_empty() {
+                " ".to_string()
+            } else {
+                line.to_string()
+            })
+        }))
 }
 
 fn action_button<F>(
@@ -433,6 +548,25 @@ fn status_line(editor: &SettingsEditor) -> impl IntoElement + use<> {
         div().text_xs().text_color(rgb(0x8ad7a0)).child(ok.clone())
     } else {
         div()
+    }
+}
+
+fn mono_font() -> Font {
+    Font {
+        family: "Consolas".into(),
+        features: FontFeatures::default(),
+        fallbacks: Some(FontFallbacks::from_fonts(vec![
+            "Cascadia Mono".into(),
+            "Cascadia Code".into(),
+            "Menlo".into(),
+            "Monaco".into(),
+            "ui-monospace".into(),
+            "monospace".into(),
+            "Yu Gothic UI".into(),
+            "Segoe UI".into(),
+        ])),
+        weight: FontWeight::default(),
+        style: FontStyle::default(),
     }
 }
 

--- a/apps/discovery-server/Cargo.toml
+++ b/apps/discovery-server/Cargo.toml
@@ -26,3 +26,4 @@ ctrlc = "3"
 gpui.workspace = true
 openmediatransport.workspace = true
 suite-core.workspace = true
+if-addrs = "0.15"

--- a/apps/discovery-server/Cargo.toml
+++ b/apps/discovery-server/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "omt-discovery-server"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "OMT Discovery Server — CLI and GPUI status console"
+
+[lib]
+name = "omt_discovery_server"
+path = "src/lib.rs"
+
+[[bin]]
+name = "omt-discovery-server"
+path = "src/bin/cli.rs"
+
+[[bin]]
+name = "omt-discovery-server-gui"
+path = "src/bin/gui.rs"
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+ctrlc = "3"
+gpui.workspace = true
+openmediatransport.workspace = true
+suite-core.workspace = true

--- a/apps/discovery-server/src/bin/cli.rs
+++ b/apps/discovery-server/src/bin/cli.rs
@@ -1,0 +1,66 @@
+//! OMT Discovery Server CLI — matches the official console app.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use clap::Parser;
+use omt_discovery_server::{ServerController, ServerSettings};
+use openmediatransport::DISCOVERY_SERVER_DEFAULT_PORT;
+use suite_core::init_tracing;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "omt-discovery-server",
+    about = "OMT Discovery Server (TCP relay, default port 6399)"
+)]
+struct Args {
+    /// Listen port.
+    #[arg(short, long, default_value_t = DISCOVERY_SERVER_DEFAULT_PORT)]
+    port: u16,
+    /// Bind address (`::` = dual-stack any, matching the official app).
+    #[arg(short, long, default_value = "::")]
+    bind: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    init_tracing();
+    let args = Args::parse();
+
+    println!("OMTDiscoveryServer");
+    println!("Command Line: omt-discovery-server --port <port> [--bind <addr>]");
+
+    let mut server = ServerController::new(ServerSettings {
+        bind: args.bind,
+        port: args.port,
+    });
+    server.start().map_err(anyhow::Error::msg)?;
+    println!(
+        "Server running on {}, press CTRL+C to exit...",
+        server.bind_addr()
+    );
+
+    let running = Arc::new(AtomicBool::new(true));
+    let flag = Arc::clone(&running);
+    ctrlc::set_handler(move || {
+        flag.store(false, Ordering::SeqCst);
+    })?;
+
+    let mut printed = 0usize;
+    while running.load(Ordering::SeqCst) {
+        server.poll();
+        let events = server.events();
+        if events.len() > printed {
+            for line in &events[printed..] {
+                println!("{line}");
+            }
+            printed = events.len();
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    server.stop().map_err(anyhow::Error::msg)?;
+    println!("stopped");
+    Ok(())
+}

--- a/apps/discovery-server/src/bin/gui.rs
+++ b/apps/discovery-server/src/bin/gui.rs
@@ -1,0 +1,34 @@
+//! OMT Discovery Server GUI.
+
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+#[path = "../ui.rs"]
+mod ui;
+
+use clap::Parser;
+use suite_core::{LaunchOverrides, init_tracing, t};
+
+#[derive(Debug, Parser)]
+#[command(name = "omt-discovery-server-gui", about = "OMT Discovery Server")]
+struct Args {
+    /// UI language (`en` / `ja`).
+    #[arg(long)]
+    language: Option<String>,
+    /// Theme (`light` / `dark` / `system`).
+    #[arg(long)]
+    theme: Option<String>,
+}
+
+fn main() -> anyhow::Result<()> {
+    init_tracing();
+
+    let args = Args::parse();
+    let overrides = LaunchOverrides::resolve(
+        args.language.as_deref().and_then(|s| s.parse().ok()),
+        args.theme.as_deref().and_then(|s| s.parse().ok()),
+        None,
+    );
+
+    let title = t(overrides.language, "tool.discovery_server").to_string();
+    ui::run_gpui(title, overrides.language)
+}

--- a/apps/discovery-server/src/lib.rs
+++ b/apps/discovery-server/src/lib.rs
@@ -1,0 +1,257 @@
+//! Shared Discovery Server controller used by the CLI and GUI.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use openmediatransport::{
+    DISCOVERY_SERVER_DEFAULT_PORT, DiscoveryServerEvent, DiscoveryServerHandle,
+    DiscoveryServerSnapshot, OmtAddress, default_bind_addr,
+};
+
+/// Maximum retained GUI/CLI event lines.
+const MAX_EVENTS: usize = 200;
+
+/// Bind + port settings for the in-process discovery server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerSettings {
+    /// Bind host (`::`, `0.0.0.0`, or a unicast address).
+    pub bind: String,
+    /// TCP port (default 6399).
+    pub port: u16,
+}
+
+impl Default for ServerSettings {
+    fn default() -> Self {
+        Self {
+            bind: "::".into(),
+            port: DISCOVERY_SERVER_DEFAULT_PORT,
+        }
+    }
+}
+
+/// Runtime wrapper around [`DiscoveryServerHandle`].
+pub struct ServerController {
+    handle: DiscoveryServerHandle,
+    settings: ServerSettings,
+    events: Vec<String>,
+}
+
+impl ServerController {
+    /// Create a stopped controller with the given listen settings.
+    pub fn new(settings: ServerSettings) -> Self {
+        Self {
+            handle: DiscoveryServerHandle::with_bind(parse_bind(&settings.bind, settings.port)),
+            settings,
+            events: Vec::new(),
+        }
+    }
+
+    /// Current bind/port text fields.
+    pub fn settings(&self) -> &ServerSettings {
+        &self.settings
+    }
+
+    /// Replace bind/port. Fails while the server is running.
+    pub fn set_settings(&mut self, settings: ServerSettings) -> Result<(), String> {
+        if self.is_running() {
+            return Err("stop the server before changing bind or port".into());
+        }
+        let bind = parse_bind(&settings.bind, settings.port);
+        self.handle.set_bind(bind).map_err(|e| e.to_string())?;
+        self.settings = settings;
+        Ok(())
+    }
+
+    /// Bind and start the accept loop.
+    pub fn start(&mut self) -> Result<(), String> {
+        let bind = parse_bind(&self.settings.bind, self.settings.port);
+        self.handle.set_bind(bind).map_err(|e| e.to_string())?;
+        self.handle.start().map_err(|e| e.to_string())?;
+        self.push_event(format!("starting on {}", self.handle.bind()));
+        Ok(())
+    }
+
+    /// Stop and join the accept loop.
+    pub fn stop(&mut self) -> Result<(), String> {
+        self.handle.join().map_err(|e| e.to_string())?;
+        self.drain_handle_events();
+        Ok(())
+    }
+
+    /// True while the accept loop is running.
+    pub fn is_running(&self) -> bool {
+        self.handle.is_running()
+    }
+
+    /// Bound address after start (OS-assigned if port was 0).
+    pub fn bind_addr(&self) -> SocketAddr {
+        self.handle.bind()
+    }
+
+    /// Connected peers and registered sources.
+    pub fn snapshot(&self) -> DiscoveryServerSnapshot {
+        self.handle.snapshot()
+    }
+
+    /// Drain handle events into the local log.
+    pub fn poll(&mut self) {
+        self.drain_handle_events();
+    }
+
+    /// Recent human-readable event lines (newest last).
+    pub fn events(&self) -> &[String] {
+        &self.events
+    }
+
+    /// Drop retained event lines.
+    pub fn clear_events(&mut self) {
+        self.events.clear();
+    }
+
+    fn drain_handle_events(&mut self) {
+        for event in self.handle.drain_events() {
+            self.push_event(format_event(&event));
+        }
+    }
+
+    fn push_event(&mut self, line: String) {
+        self.events.push(line);
+        let extra = self.events.len().saturating_sub(MAX_EVENTS);
+        if extra > 0 {
+            self.events.drain(0..extra);
+        }
+    }
+}
+
+/// Parse a bind host plus port into a [`SocketAddr`].
+pub fn parse_bind(bind: &str, port: u16) -> SocketAddr {
+    let bind = bind.trim();
+    if bind.is_empty() || bind == "::" {
+        return default_bind_addr(port);
+    }
+    if bind == "0.0.0.0" {
+        return SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
+    }
+    if let Ok(addr) = bind.parse::<SocketAddr>() {
+        return addr;
+    }
+    if let Ok(ip) = bind.parse::<IpAddr>() {
+        return SocketAddr::new(ip, port);
+    }
+    if let Ok(v6) = bind.parse::<Ipv6Addr>() {
+        return SocketAddr::from((v6, port));
+    }
+    default_bind_addr(port)
+}
+
+fn format_event(event: &DiscoveryServerEvent) -> String {
+    match event {
+        DiscoveryServerEvent::Started { bind } => format!("started on {bind}"),
+        DiscoveryServerEvent::ClientConnected { peer } => format!("connected {peer}"),
+        DiscoveryServerEvent::ClientDisconnected { peer } => format!("disconnected {peer}"),
+        DiscoveryServerEvent::SourceRegistered { address, peer } => {
+            format!("added {} from {peer}", format_source(address))
+        }
+        DiscoveryServerEvent::SourceRemoved { address, peer } => {
+            format!("removed {} from {peer}", format_source(address))
+        }
+        DiscoveryServerEvent::Error { message } => format!("error {message}"),
+        DiscoveryServerEvent::Stopped => "stopped".into(),
+    }
+}
+
+fn format_source(address: &OmtAddress) -> String {
+    format!("{}:{}", address.instance_name(), address.port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    use openmediatransport::{DiscoveryClient, OmtAddress};
+
+    fn wait_until(timeout: Duration, mut pred: impl FnMut() -> bool) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if pred() {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        pred()
+    }
+
+    #[test]
+    fn parse_bind_defaults_to_ipv6_any() {
+        let addr = parse_bind("::", 6399);
+        assert!(addr.is_ipv6());
+        assert!(addr.ip().is_unspecified());
+        assert_eq!(addr.port(), 6399);
+        assert_eq!(
+            parse_bind("127.0.0.1", 6400),
+            SocketAddr::from(([127, 0, 0, 1], 6400))
+        );
+    }
+
+    #[test]
+    fn controller_start_register_disconnect_stop() {
+        let mut server = ServerController::new(ServerSettings {
+            bind: "127.0.0.1".into(),
+            port: 0,
+        });
+        server.start().unwrap();
+        assert!(wait_until(Duration::from_secs(2), || server.is_running()));
+        let port = server.bind_addr().port();
+        assert_ne!(port, 0);
+
+        let mut client = DiscoveryClient::new("127.0.0.1");
+        client.port = port;
+        client.connect().unwrap();
+        let mut addr = OmtAddress::from_full_name("CTRLHOST (Cam1)", 6411);
+        addr.addresses = vec!["10.0.0.9".into()];
+        client.register(&addr).unwrap();
+
+        assert!(wait_until(Duration::from_secs(5), || {
+            server.poll();
+            server
+                .snapshot()
+                .sources
+                .iter()
+                .any(|s| s.instance_name() == "CTRLHOST (Cam1)")
+        }));
+        assert_eq!(server.snapshot().peer_count(), 1);
+
+        drop(client);
+        assert!(wait_until(Duration::from_secs(3), || {
+            server.poll();
+            server.snapshot().peer_count() == 0 && server.snapshot().sources.is_empty()
+        }));
+
+        server.stop().unwrap();
+        assert!(!server.is_running());
+        server.poll();
+        assert!(server.events().iter().any(|e| e.contains("started")));
+        assert!(server.events().iter().any(|e| e.contains("added")));
+        assert!(server.events().iter().any(|e| e.contains("stopped")));
+    }
+
+    #[test]
+    fn controller_start_fails_when_port_busy() {
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = occupied.local_addr().unwrap().port();
+        let mut server = ServerController::new(ServerSettings {
+            bind: "127.0.0.1".into(),
+            port,
+        });
+        let err = server.start().unwrap_err();
+        drop(occupied);
+        assert!(
+            err.to_ascii_lowercase().contains("addr")
+                || err.contains("10048")
+                || err.contains("in use")
+                || err.contains("os error"),
+            "unexpected start error: {err}"
+        );
+    }
+}

--- a/apps/discovery-server/src/lib.rs
+++ b/apps/discovery-server/src/lib.rs
@@ -143,6 +143,47 @@ pub fn parse_bind(bind: &str, port: u16) -> SocketAddr {
     default_bind_addr(port)
 }
 
+/// A selectable listen address (all-interfaces or a NIC unicast IP).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BindChoice {
+    /// Value written into the bind field (`::`, `0.0.0.0`, or a unicast IP).
+    pub bind: String,
+    /// Interface name when this is a NIC address.
+    pub iface: Option<String>,
+}
+
+/// Bind targets: dual-stack any, IPv4 any, then each NIC address.
+pub fn bind_choices() -> Vec<BindChoice> {
+    let mut choices = vec![
+        BindChoice {
+            bind: "::".into(),
+            iface: None,
+        },
+        BindChoice {
+            bind: "0.0.0.0".into(),
+            iface: None,
+        },
+    ];
+    let mut seen = std::collections::BTreeSet::from(["::".to_string(), "0.0.0.0".to_string()]);
+    if let Ok(ifaces) = if_addrs::get_if_addrs() {
+        for iface in ifaces {
+            let ip = iface.ip();
+            if ip.is_unspecified() {
+                continue;
+            }
+            let bind = ip.to_string();
+            if !seen.insert(bind.clone()) {
+                continue;
+            }
+            choices.push(BindChoice {
+                bind,
+                iface: Some(iface.name),
+            });
+        }
+    }
+    choices
+}
+
 fn format_event(event: &DiscoveryServerEvent) -> String {
     match event {
         DiscoveryServerEvent::Started { bind } => format!("started on {bind}"),
@@ -191,6 +232,17 @@ mod tests {
         assert_eq!(
             parse_bind("127.0.0.1", 6400),
             SocketAddr::from(([127, 0, 0, 1], 6400))
+        );
+    }
+
+    #[test]
+    fn bind_choices_include_any_and_local_addrs() {
+        let choices = bind_choices();
+        assert!(choices.iter().any(|c| c.bind == "::" && c.iface.is_none()));
+        assert!(
+            choices
+                .iter()
+                .any(|c| c.bind == "0.0.0.0" && c.iface.is_none())
         );
     }
 

--- a/apps/discovery-server/src/ui.rs
+++ b/apps/discovery-server/src/ui.rs
@@ -8,7 +8,7 @@ use gpui::{
     FontStyle, FontWeight, InteractiveElement, KeyDownEvent, SharedString, Timer, Window,
     WindowBounds, WindowOptions, div, prelude::*, px, rgb, size,
 };
-use omt_discovery_server::{ServerController, ServerSettings};
+use omt_discovery_server::{BindChoice, ServerController, ServerSettings, bind_choices};
 use suite_core::{
     DiscoveryServerConfig, Language, load_discovery_server_config, save_discovery_server_config, t,
 };
@@ -22,7 +22,7 @@ enum EditTarget {
 
 pub fn run_gpui(title: String, language: Language) -> Result<()> {
     Application::new().run(move |cx: &mut App| {
-        let bounds = Bounds::centered(None, size(px(820.0), px(640.0)), cx);
+        let bounds = Bounds::centered(None, size(px(820.0), px(720.0)), cx);
         let title = SharedString::from(title);
         cx.open_window(
             WindowOptions {
@@ -46,6 +46,7 @@ struct ServerView {
     language: Language,
     bind: String,
     port: String,
+    nics: Vec<BindChoice>,
     controller: ServerController,
     editing: EditTarget,
     error: Option<String>,
@@ -65,6 +66,7 @@ impl ServerView {
             language,
             bind: cfg.bind,
             port: cfg.port.to_string(),
+            nics: bind_choices(),
             controller: ServerController::new(settings),
             editing: EditTarget::None,
             error: None,
@@ -79,6 +81,9 @@ impl ServerView {
             Timer::after(Duration::from_millis(200)).await;
             this.update(cx, |this, cx| {
                 this.controller.poll();
+                if !this.controller.is_running() {
+                    this.nics = bind_choices();
+                }
                 this.schedule_tick(cx);
                 cx.notify();
             })
@@ -114,6 +119,20 @@ impl ServerView {
         self.controller.set_settings(settings)?;
         self.persist();
         Ok(())
+    }
+
+    fn select_bind(&mut self, bind: String, cx: &mut Context<Self>) {
+        if self.controller.is_running() {
+            return;
+        }
+        self.bind = bind;
+        self.editing = EditTarget::None;
+        if let Err(e) = self.apply_settings() {
+            self.error = Some(e);
+        } else {
+            self.error = None;
+        }
+        cx.notify();
     }
 
     fn start(&mut self, cx: &mut Context<Self>) {
@@ -238,6 +257,13 @@ impl Render for ServerView {
                     )
                     .child(
                         div()
+                            .text_xs()
+                            .opacity(0.65)
+                            .child(t(lang, "discovery.nic")),
+                    )
+                    .child(nic_chips(cx, lang, &self.nics, &self.bind, running))
+                    .child(
+                        div()
                             .flex()
                             .gap_2()
                             .items_center()
@@ -310,6 +336,59 @@ impl Render for ServerView {
                     .child(event_log(self.controller.events())),
             )
     }
+}
+
+fn nic_chips(
+    cx: &mut Context<ServerView>,
+    lang: Language,
+    nics: &[BindChoice],
+    selected: &str,
+    running: bool,
+) -> impl IntoElement {
+    let selected = selected.trim().to_string();
+    let mut chips = Vec::new();
+    for (i, choice) in nics.iter().cloned().enumerate() {
+        chips.push(nic_chip(cx, lang, i, choice, &selected, running).into_any_element());
+    }
+    div()
+        .flex()
+        .flex_row()
+        .flex_wrap()
+        .gap_2()
+        .children(chips)
+}
+
+fn nic_chip(
+    cx: &mut Context<ServerView>,
+    lang: Language,
+    index: usize,
+    choice: BindChoice,
+    selected: &str,
+    running: bool,
+) -> impl IntoElement {
+    let active = selected == choice.bind;
+    let label = match choice.iface.as_deref() {
+        None if choice.bind == "::" => t(lang, "discovery.nic_all").to_string(),
+        None if choice.bind == "0.0.0.0" => t(lang, "discovery.nic_all_v4").to_string(),
+        Some(name) => format!("{name}  {}", choice.bind),
+        None => choice.bind.clone(),
+    };
+    let bind = choice.bind.clone();
+    div()
+        .id(SharedString::from(format!("nic-{index}")))
+        .px_2()
+        .py_1()
+        .rounded_md()
+        .border_1()
+        .border_color(if active { rgb(0x2f6fed) } else { rgb(0x2a3340) })
+        .bg(if active { rgb(0x1d2b44) } else { rgb(0x243041) })
+        .opacity(if running { 0.55 } else { 1.0 })
+        .cursor_pointer()
+        .text_xs()
+        .child(label)
+        .on_click(cx.listener(move |this, _, _, cx| {
+            this.select_bind(bind.clone(), cx);
+        }))
 }
 
 fn sources_list(lang: Language, sources: &[openmediatransport::OmtAddress]) -> impl IntoElement {

--- a/apps/discovery-server/src/ui.rs
+++ b/apps/discovery-server/src/ui.rs
@@ -1,0 +1,452 @@
+//! GPUI Discovery Server console.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use gpui::{
+    App, Application, Bounds, Context, FocusHandle, Focusable, Font, FontFallbacks, FontFeatures,
+    FontStyle, FontWeight, InteractiveElement, KeyDownEvent, SharedString, Timer, Window,
+    WindowBounds, WindowOptions, div, prelude::*, px, rgb, size,
+};
+use omt_discovery_server::{ServerController, ServerSettings};
+use suite_core::{
+    DiscoveryServerConfig, Language, load_discovery_server_config, save_discovery_server_config, t,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EditTarget {
+    None,
+    Bind,
+    Port,
+}
+
+pub fn run_gpui(title: String, language: Language) -> Result<()> {
+    Application::new().run(move |cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(820.0), px(640.0)), cx);
+        let title = SharedString::from(title);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                titlebar: Some(gpui::TitlebarOptions {
+                    title: Some(title.clone()),
+                    ..Default::default()
+                }),
+                app_id: Some(suite_core::ToolId::DiscoveryServer.binary_name().into()),
+                ..Default::default()
+            },
+            move |_, cx| cx.new(|cx| ServerView::new(cx, language)),
+        )
+        .expect("open GPUI Discovery Server window");
+        cx.activate(true);
+    });
+    Ok(())
+}
+
+struct ServerView {
+    language: Language,
+    bind: String,
+    port: String,
+    controller: ServerController,
+    editing: EditTarget,
+    error: Option<String>,
+    focus_handle: FocusHandle,
+}
+
+impl ServerView {
+    fn new(cx: &mut Context<Self>, language: Language) -> Self {
+        let cfg = load_discovery_server_config()
+            .unwrap_or_default()
+            .sanitized();
+        let settings = ServerSettings {
+            bind: cfg.bind.clone(),
+            port: cfg.port,
+        };
+        let view = Self {
+            language,
+            bind: cfg.bind,
+            port: cfg.port.to_string(),
+            controller: ServerController::new(settings),
+            editing: EditTarget::None,
+            error: None,
+            focus_handle: cx.focus_handle(),
+        };
+        view.schedule_tick(cx);
+        view
+    }
+
+    fn schedule_tick(&self, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            Timer::after(Duration::from_millis(200)).await;
+            this.update(cx, |this, cx| {
+                this.controller.poll();
+                this.schedule_tick(cx);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn persist(&self) {
+        let port = self.port.parse().unwrap_or(6399);
+        let cfg = DiscoveryServerConfig {
+            schema_version: 1,
+            bind: self.bind.clone(),
+            port,
+        }
+        .sanitized();
+        let _ = save_discovery_server_config(&cfg);
+    }
+
+    fn apply_settings(&mut self) -> Result<(), String> {
+        let port: u16 = self
+            .port
+            .trim()
+            .parse()
+            .map_err(|_| "port must be an integer from 1 to 65535".to_string())?;
+        if port == 0 {
+            return Err("port must be an integer from 1 to 65535".into());
+        }
+        let settings = ServerSettings {
+            bind: self.bind.clone(),
+            port,
+        };
+        self.controller.set_settings(settings)?;
+        self.persist();
+        Ok(())
+    }
+
+    fn start(&mut self, cx: &mut Context<Self>) {
+        match self.apply_settings().and_then(|()| self.controller.start()) {
+            Ok(()) => self.error = None,
+            Err(e) => self.error = Some(e),
+        }
+        cx.notify();
+    }
+
+    fn stop(&mut self, cx: &mut Context<Self>) {
+        match self.controller.stop() {
+            Ok(()) => self.error = None,
+            Err(e) => self.error = Some(e),
+        }
+        cx.notify();
+    }
+
+    fn apply_key(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) {
+        if self.editing == EditTarget::None || self.controller.is_running() {
+            return;
+        }
+        let key = event.keystroke.key.as_str();
+        if key == "escape" || key == "enter" {
+            self.editing = EditTarget::None;
+            cx.notify();
+            return;
+        }
+        let field = match self.editing {
+            EditTarget::Bind => &mut self.bind,
+            EditTarget::Port => &mut self.port,
+            EditTarget::None => return,
+        };
+        if key == "backspace" {
+            field.pop();
+            cx.notify();
+            return;
+        }
+        if let Some(ch) = event.keystroke.key_char.as_deref()
+            && ch.chars().all(|c| !c.is_control())
+            && field.len() + ch.len() <= 64
+        {
+            field.push_str(ch);
+            cx.notify();
+        }
+    }
+}
+
+impl Focusable for ServerView {
+    fn focus_handle(&self, _: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for ServerView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let lang = self.language;
+        let running = self.controller.is_running();
+        let snap = self.controller.snapshot();
+        let status = if running {
+            t(lang, "discovery.running")
+        } else {
+            t(lang, "discovery.stopped")
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .font(ui_font())
+            .bg(rgb(0x1a1d23))
+            .text_color(rgb(0xedf2f7))
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                this.apply_key(event, cx);
+            }))
+            .child(
+                div()
+                    .px_4()
+                    .py_2()
+                    .border_b_1()
+                    .border_color(rgb(0x2a3340))
+                    .font_weight(FontWeight::BOLD)
+                    .child(t(lang, "tool.discovery_server")),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_3()
+                    .p_4()
+                    .flex_1()
+                    .min_h_0()
+                    .child(
+                        div()
+                            .flex()
+                            .gap_3()
+                            .child(field(
+                                cx,
+                                "bind",
+                                t(lang, "discovery.bind"),
+                                &self.bind,
+                                self.editing == EditTarget::Bind,
+                                !running,
+                                EditTarget::Bind,
+                            ))
+                            .child(field(
+                                cx,
+                                "port",
+                                t(lang, "discovery.port"),
+                                &self.port,
+                                self.editing == EditTarget::Port,
+                                !running,
+                                EditTarget::Port,
+                            )),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .opacity(0.65)
+                            .child(t(lang, "discovery.bind_hint")),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .gap_2()
+                            .items_center()
+                            .child(action_button(
+                                cx,
+                                "start",
+                                t(lang, "discovery.start"),
+                                rgb(0x2f6fed),
+                                running,
+                                |this, _, cx| this.start(cx),
+                            ))
+                            .child(action_button(
+                                cx,
+                                "stop",
+                                t(lang, "discovery.stop"),
+                                rgb(0xb33a3a),
+                                !running,
+                                |this, _, cx| this.stop(cx),
+                            ))
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(if running {
+                                        rgb(0x8ad7a0)
+                                    } else {
+                                        rgb(0xa0a8b4)
+                                    })
+                                    .child(status.to_string()),
+                            )
+                            .child(div().text_xs().opacity(0.8).child(format!(
+                                "{}: {}",
+                                t(lang, "discovery.peers"),
+                                snap.peer_count()
+                            ))),
+                    )
+                    .children(
+                        self.error.as_ref().map(|err| {
+                            div().text_xs().text_color(rgb(0xff8a8a)).child(err.clone())
+                        }),
+                    )
+                    .child(
+                        div()
+                            .font_weight(FontWeight::BOLD)
+                            .child(t(lang, "discovery.sources")),
+                    )
+                    .child(sources_list(lang, &snap.sources))
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .child(
+                                div()
+                                    .font_weight(FontWeight::BOLD)
+                                    .child(t(lang, "discovery.log")),
+                            )
+                            .child(action_button(
+                                cx,
+                                "clear-log",
+                                t(lang, "discovery.clear_log"),
+                                rgb(0x243041),
+                                false,
+                                |this, _, cx| {
+                                    this.controller.clear_events();
+                                    cx.notify();
+                                },
+                            )),
+                    )
+                    .child(event_log(self.controller.events())),
+            )
+    }
+}
+
+fn sources_list(lang: Language, sources: &[openmediatransport::OmtAddress]) -> impl IntoElement {
+    if sources.is_empty() {
+        return div()
+            .text_xs()
+            .opacity(0.65)
+            .child(t(lang, "discovery.none"));
+    }
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .children(sources.iter().map(|src| {
+            let ips = src.addresses.join(", ");
+            div()
+                .text_xs()
+                .child(format!("{}  :{}  {ips}", src.instance_name(), src.port))
+        }))
+}
+
+fn event_log(events: &[String]) -> impl IntoElement {
+    div()
+        .id("event-log")
+        .flex()
+        .flex_col()
+        .flex_1()
+        .min_h(px(160.0))
+        .overflow_y_scroll()
+        .p_2()
+        .rounded_md()
+        .bg(rgb(0x0c1016))
+        .border_1()
+        .border_color(rgb(0x2a3340))
+        .children(
+            events
+                .iter()
+                .rev()
+                .take(80)
+                .map(|line| div().text_xs().opacity(0.9).child(line.clone())),
+        )
+}
+
+fn field(
+    cx: &mut Context<ServerView>,
+    id: &'static str,
+    caption: &str,
+    value: &str,
+    editing: bool,
+    enabled: bool,
+    target: EditTarget,
+) -> impl IntoElement {
+    let display = if editing {
+        format!("{value}|")
+    } else {
+        value.to_string()
+    };
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .flex_1()
+        .child(div().text_xs().opacity(0.65).child(caption.to_string()))
+        .child(
+            div()
+                .id(id)
+                .px_2()
+                .py_1()
+                .rounded_md()
+                .border_1()
+                .border_color(if editing {
+                    rgb(0x2f6fed)
+                } else {
+                    rgb(0x2a3340)
+                })
+                .bg(rgb(0x0c1016))
+                .opacity(if enabled { 1.0 } else { 0.55 })
+                .cursor_text()
+                .text_xs()
+                .child(display)
+                .on_click(cx.listener(move |this, _, window, cx| {
+                    if enabled {
+                        this.editing = target;
+                        this.focus_handle.focus(window);
+                        cx.notify();
+                    }
+                })),
+        )
+}
+
+fn action_button<F>(
+    cx: &mut Context<ServerView>,
+    id: &'static str,
+    label: &str,
+    color: gpui::Rgba,
+    disabled: bool,
+    on_click: F,
+) -> impl IntoElement
+where
+    F: Fn(&mut ServerView, &gpui::ClickEvent, &mut Context<ServerView>) + 'static + Clone,
+{
+    div()
+        .id(id)
+        .px_3()
+        .py_1()
+        .rounded_md()
+        .bg(color)
+        .opacity(if disabled { 0.45 } else { 1.0 })
+        .cursor_pointer()
+        .text_xs()
+        .font_weight(FontWeight::SEMIBOLD)
+        .child(label.to_string())
+        .on_click(cx.listener(move |this, event, _, cx| {
+            if !disabled {
+                on_click(this, event, cx);
+            }
+        }))
+}
+
+fn ui_font() -> Font {
+    Font {
+        family: ".SystemUIFont".into(),
+        features: FontFeatures::default(),
+        fallbacks: Some(FontFallbacks::from_fonts(vec![
+            "Yu Gothic UI".into(),
+            "Yu Gothic".into(),
+            "Meiryo UI".into(),
+            "Meiryo".into(),
+            "MS UI Gothic".into(),
+            "Segoe UI".into(),
+            "Hiragino Sans".into(),
+            "Hiragino Kaku Gothic ProN".into(),
+            "Noto Sans CJK JP".into(),
+            "Noto Sans JP".into(),
+            "Source Han Sans JP".into(),
+        ])),
+        weight: FontWeight::default(),
+        style: FontStyle::default(),
+    }
+}

--- a/apps/discovery-server/src/ui.rs
+++ b/apps/discovery-server/src/ui.rs
@@ -350,12 +350,7 @@ fn nic_chips(
     for (i, choice) in nics.iter().cloned().enumerate() {
         chips.push(nic_chip(cx, lang, i, choice, &selected, running).into_any_element());
     }
-    div()
-        .flex()
-        .flex_row()
-        .flex_wrap()
-        .gap_2()
-        .children(chips)
+    div().flex().flex_row().flex_wrap().gap_2().children(chips)
 }
 
 fn nic_chip(

--- a/apps/launcher/package.json
+++ b/apps/launcher/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "bun@1.2.19",
   "scripts": {
-    "dev": "tauri dev",
+    "dev": "bun ../../scripts/prepare-dev-sidecars.js && tauri dev",
     "dev:frontend": "vite",
     "build": "tsc && vite build",
     "tauri": "tauri"

--- a/apps/launcher/src-tauri/binaries/.gitignore
+++ b/apps/launcher/src-tauri/binaries/.gitignore
@@ -2,6 +2,9 @@
 # Tauri expects:
 #   omt-studio-monitor-<target-triple>[.exe]
 #   omt-test-patterns-<target-triple>[.exe]
+#   omt-config-manager-<target-triple>[.exe]
+#   omt-discovery-server-gui-<target-triple>[.exe]
+#   omt-discovery-server-<target-triple>[.exe]
 *
 !.gitignore
 !README.md

--- a/apps/launcher/src-tauri/binaries/README.md
+++ b/apps/launcher/src-tauri/binaries/README.md
@@ -1,6 +1,8 @@
 # Sidecar binaries
 
-Build the tools, then run `scripts/prepare-sidecars.ps1` (Windows) or `scripts/prepare-sidecars.sh` before `bun run tauri build`.
+For `tauri dev`, run `bun run tools:sidecars:dev` (or just `bun run dev`) so debug builds are copied here. `ensure-sidecar-placeholders.ps1` only writes a tiny stub when a tool has not been built — it must not copy `cmd.exe`.
+
+For packaging, build the tools, then run `scripts/prepare-sidecars.ps1` (Windows) or `scripts/prepare-sidecars.sh` before `bun run tauri build`.
 
 Required names:
 

--- a/apps/launcher/src-tauri/binaries/README.md
+++ b/apps/launcher/src-tauri/binaries/README.md
@@ -6,3 +6,6 @@ Required names:
 
 - `omt-studio-monitor-<triple>`
 - `omt-test-patterns-<triple>`
+- `omt-config-manager-<triple>`
+- `omt-discovery-server-gui-<triple>`
+- `omt-discovery-server-<triple>`

--- a/apps/launcher/src-tauri/linux/omt-config-manager.desktop
+++ b/apps/launcher/src-tauri/linux/omt-config-manager.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=OMT Config Manager
+Comment=View and edit the global OMT settings.xml
+Exec=omt-config-manager
+TryExec=omt-config-manager
+Icon=OMT Tools
+Terminal=false
+StartupNotify=true
+StartupWMClass=omt-config-manager
+Categories=AudioVideo;Video;AudioVideoEditing;
+Keywords=OMT;NDI;settings;config;

--- a/apps/launcher/src-tauri/linux/omt-discovery-server.desktop
+++ b/apps/launcher/src-tauri/linux/omt-discovery-server.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=OMT Discovery Server
+Comment=Run an OMT discovery server for networks that block multicast
+Exec=omt-discovery-server-gui
+TryExec=omt-discovery-server-gui
+Icon=OMT Tools
+Terminal=false
+StartupNotify=true
+StartupWMClass=omt-discovery-server-gui
+Categories=AudioVideo;Video;AudioVideoEditing;
+Keywords=OMT;NDI;discovery;server;

--- a/apps/launcher/src-tauri/src/lib.rs
+++ b/apps/launcher/src-tauri/src/lib.rs
@@ -5,7 +5,7 @@ mod tools;
 
 use serde::{Deserialize, Serialize};
 use suite_core::{
-    Language, SimdCapabilities, SuiteManifest, ThemePreference, ToolId, load_config, save_config,
+    Language, SimdCapabilities, SuiteManifest, ThemePreference, load_config, save_config,
     suite_manifest, t,
 };
 use tauri::Manager;
@@ -91,11 +91,7 @@ fn build_state(app: &tauri::AppHandle) -> Result<LauncherState, String> {
     for info in &manifest.tools {
         let available = tools::tool_available(app, info.id);
         tools.push(ToolCard {
-            id: match info.id {
-                ToolId::StudioMonitor => "studio-monitor".into(),
-                ToolId::TestPatterns => "test-patterns".into(),
-                ToolId::ScreenCapture => "screen-capture".into(),
-            },
+            id: info.id.os_entry_id().to_string(),
             title: t(cfg.language, info.id.title_key()).to_string(),
             description: t(cfg.language, info.id.description_key()).to_string(),
             binary: info.binary.clone(),

--- a/apps/launcher/src-tauri/src/os_shortcuts.rs
+++ b/apps/launcher/src-tauri/src/os_shortcuts.rs
@@ -322,6 +322,8 @@ fn linux_desktop_entry(tool: ToolId, exec: &str) -> String {
     let comment = match tool {
         ToolId::StudioMonitor => "Browse and view OMT sources on the LAN",
         ToolId::TestPatterns => "Pick a pattern and send video + tone over OMT",
+        ToolId::ConfigManager => "View and edit the global OMT settings.xml",
+        ToolId::DiscoveryServer => "Run an OMT discovery server for networks that block multicast",
         ToolId::ScreenCapture => "Capture the desktop and send over OMT",
     };
     format!(

--- a/apps/launcher/src-tauri/src/tools.rs
+++ b/apps/launcher/src-tauri/src/tools.rs
@@ -11,6 +11,8 @@ pub fn parse_tool_id(tool_id: &str) -> Result<ToolId, String> {
     match tool_id {
         "studio-monitor" => Ok(ToolId::StudioMonitor),
         "test-patterns" => Ok(ToolId::TestPatterns),
+        "config-manager" => Ok(ToolId::ConfigManager),
+        "discovery-server" => Ok(ToolId::DiscoveryServer),
         "screen-capture" => Ok(ToolId::ScreenCapture),
         _ => Err(format!("unknown tool: {tool_id}")),
     }

--- a/apps/launcher/src-tauri/src/tools.rs
+++ b/apps/launcher/src-tauri/src/tools.rs
@@ -1,10 +1,15 @@
 //! Sidecar / local binary launch helpers.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use suite_core::{LaunchOverrides, ToolId, load_config};
 use tauri::{AppHandle, Manager};
+
+/// `ensure-sidecar-placeholders` used to copy `cmd.exe` when a tool had not
+/// been built yet. Tauri then copied that file next to the launcher as
+/// `omt-config-manager.exe`, so Launch opened a console instead of the GUI.
+const MIN_TOOL_BYTES: u64 = 64 * 1024;
 
 /// Parse a launcher / CLI tool id (`studio-monitor`, `test-patterns`, ...).
 pub fn parse_tool_id(tool_id: &str) -> Result<ToolId, String> {
@@ -31,7 +36,7 @@ pub fn resolve_tool_path(app: &AppHandle, tool: ToolId) -> Result<PathBuf, Strin
             resource.join("binaries").join(format!("{name}.exe")),
         ];
         for path in candidates {
-            if path.exists() {
+            if is_usable_tool_binary(&path) {
                 return Ok(path);
             }
         }
@@ -46,7 +51,7 @@ pub fn resolve_tool_path(app: &AppHandle, tool: ToolId) -> Result<PathBuf, Strin
                 dir.join("binaries").join(name),
                 dir.join("binaries").join(format!("{name}.exe")),
             ] {
-                if path.exists() {
+                if is_usable_tool_binary(&path) {
                     return Ok(path);
                 }
             }
@@ -66,10 +71,10 @@ pub fn resolve_tool_path(app: &AppHandle, tool: ToolId) -> Result<PathBuf, Strin
             .join("target")
             .join(profile)
             .join(format!("{name}.exe"));
-        if path_exe.exists() {
+        if is_usable_tool_binary(&path_exe) {
             return Ok(path_exe);
         }
-        if path.exists() {
+        if is_usable_tool_binary(&path) {
             return Ok(path);
         }
     }
@@ -86,7 +91,7 @@ fn resolve_launch_path(app: &AppHandle, tool: ToolId) -> Result<PathBuf, String>
     #[cfg(target_os = "macos")]
     {
         if let Some(wrapped) = crate::os_shortcuts::macos_wrapped_executable(tool) {
-            if wrapped.exists() {
+            if is_usable_tool_binary(&wrapped) {
                 return Ok(wrapped);
             }
         }
@@ -150,4 +155,50 @@ fn process_running(name: &str) -> bool {
         .status()
         .map(|s| s.success())
         .unwrap_or(false)
+}
+
+fn is_usable_tool_binary(path: &Path) -> bool {
+    let Ok(meta) = path.metadata() else {
+        return false;
+    };
+    if !meta.is_file() || meta.len() < MIN_TOOL_BYTES {
+        return false;
+    }
+    !is_cmd_exe_clone(path, meta.len())
+}
+
+#[cfg(windows)]
+fn is_cmd_exe_clone(path: &Path, len: u64) -> bool {
+    let _ = path;
+    let windir = std::env::var_os("WINDIR").unwrap_or_else(|| r"C:\Windows".into());
+    let cmd = PathBuf::from(windir).join("System32").join("cmd.exe");
+    std::fs::metadata(cmd)
+        .map(|cmd_meta| cmd_meta.len() == len)
+        .unwrap_or(false)
+}
+
+#[cfg(not(windows))]
+fn is_cmd_exe_clone(_path: &Path, _len: u64) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn rejects_tiny_stub_and_missing_path() {
+        assert!(!is_usable_tool_binary(Path::new(
+            "this-file-does-not-exist.exe"
+        )));
+        let dir = std::env::temp_dir();
+        let stub = dir.join("omt-tools-stub-binary.exe");
+        {
+            let mut f = std::fs::File::create(&stub).unwrap();
+            f.write_all(&[b'M', b'Z']).unwrap();
+        }
+        assert!(!is_usable_tool_binary(&stub));
+        let _ = std::fs::remove_file(&stub);
+    }
 }

--- a/apps/launcher/src-tauri/tauri.conf.json
+++ b/apps/launcher/src-tauri/tauri.conf.json
@@ -44,7 +44,10 @@
     "createUpdaterArtifacts": true,
     "externalBin": [
       "binaries/omt-studio-monitor",
-      "binaries/omt-test-patterns"
+      "binaries/omt-test-patterns",
+      "binaries/omt-config-manager",
+      "binaries/omt-discovery-server-gui",
+      "binaries/omt-discovery-server"
     ],
     "icon": [
       "icons/32x32.png",
@@ -73,13 +76,17 @@
       "deb": {
         "files": {
           "/usr/share/applications/lab.mikansei.omt-studio-monitor.desktop": "linux/omt-studio-monitor.desktop",
-          "/usr/share/applications/lab.mikansei.omt-test-patterns.desktop": "linux/omt-test-patterns.desktop"
+          "/usr/share/applications/lab.mikansei.omt-test-patterns.desktop": "linux/omt-test-patterns.desktop",
+          "/usr/share/applications/lab.mikansei.omt-config-manager.desktop": "linux/omt-config-manager.desktop",
+          "/usr/share/applications/lab.mikansei.omt-discovery-server.desktop": "linux/omt-discovery-server.desktop"
         }
       },
       "rpm": {
         "files": {
           "/usr/share/applications/lab.mikansei.omt-studio-monitor.desktop": "linux/omt-studio-monitor.desktop",
-          "/usr/share/applications/lab.mikansei.omt-test-patterns.desktop": "linux/omt-test-patterns.desktop"
+          "/usr/share/applications/lab.mikansei.omt-test-patterns.desktop": "linux/omt-test-patterns.desktop",
+          "/usr/share/applications/lab.mikansei.omt-config-manager.desktop": "linux/omt-config-manager.desktop",
+          "/usr/share/applications/lab.mikansei.omt-discovery-server.desktop": "linux/omt-discovery-server.desktop"
         }
       }
     }

--- a/apps/launcher/src-tauri/windows/installer.nsi
+++ b/apps/launcher/src-tauri/windows/installer.nsi
@@ -641,6 +641,9 @@ Section Install
   !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
   !insertmacro CheckIfAppIsRunning "omt-studio-monitor.exe" "Studio Monitor"
   !insertmacro CheckIfAppIsRunning "omt-test-patterns.exe" "Test Patterns"
+  !insertmacro CheckIfAppIsRunning "omt-config-manager.exe" "Config Manager"
+  !insertmacro CheckIfAppIsRunning "omt-discovery-server-gui.exe" "Discovery Server"
+  !insertmacro CheckIfAppIsRunning "omt-discovery-server.exe" "Discovery Server"
 
   ; Copy main executable
   File "${MAINBINARYSRCPATH}"
@@ -781,6 +784,9 @@ Section Uninstall
   !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
   !insertmacro CheckIfAppIsRunning "omt-studio-monitor.exe" "Studio Monitor"
   !insertmacro CheckIfAppIsRunning "omt-test-patterns.exe" "Test Patterns"
+  !insertmacro CheckIfAppIsRunning "omt-config-manager.exe" "Config Manager"
+  !insertmacro CheckIfAppIsRunning "omt-discovery-server-gui.exe" "Discovery Server"
+  !insertmacro CheckIfAppIsRunning "omt-discovery-server.exe" "Discovery Server"
 
   ; Delete the app directory and its content from disk
   ; Copy main executable
@@ -973,6 +979,12 @@ Function CreateToolStartMenuShortcuts
   ${If} ${FileExists} "$INSTDIR\omt-test-patterns.exe"
     CreateShortcut "$SMPROGRAMS\$R1\Test Patterns.lnk" "$INSTDIR\omt-test-patterns.exe" "" "$INSTDIR\${MAINBINARYNAME}.exe" 0
   ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\omt-config-manager.exe"
+    CreateShortcut "$SMPROGRAMS\$R1\Config Manager.lnk" "$INSTDIR\omt-config-manager.exe" "" "$INSTDIR\${MAINBINARYNAME}.exe" 0
+  ${EndIf}
+  ${If} ${FileExists} "$INSTDIR\omt-discovery-server-gui.exe"
+    CreateShortcut "$SMPROGRAMS\$R1\Discovery Server.lnk" "$INSTDIR\omt-discovery-server-gui.exe" "" "$INSTDIR\${MAINBINARYNAME}.exe" 0
+  ${EndIf}
 FunctionEnd
 
 Function un.DeleteToolStartMenuShortcuts
@@ -982,8 +994,12 @@ Function un.DeleteToolStartMenuShortcuts
   ${EndIf}
   Delete "$SMPROGRAMS\$R1\Studio Monitor.lnk"
   Delete "$SMPROGRAMS\$R1\Test Patterns.lnk"
+  Delete "$SMPROGRAMS\$R1\Config Manager.lnk"
+  Delete "$SMPROGRAMS\$R1\Discovery Server.lnk"
   Delete "$SMPROGRAMS\${PRODUCTNAME}\Studio Monitor.lnk"
   Delete "$SMPROGRAMS\${PRODUCTNAME}\Test Patterns.lnk"
+  Delete "$SMPROGRAMS\${PRODUCTNAME}\Config Manager.lnk"
+  Delete "$SMPROGRAMS\${PRODUCTNAME}\Discovery Server.lnk"
 FunctionEnd
 
 Function CreateOrUpdateDesktopShortcut

--- a/apps/launcher/src-tauri/windows/main.wxs
+++ b/apps/launcher/src-tauri/windows/main.wxs
@@ -222,6 +222,22 @@
                     WorkingDirectory="INSTALLDIR">
                     <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}.test-patterns"/>
                 </Shortcut>
+                <Shortcut Id="ConfigManagerStartMenuShortcut"
+                    Name="Config Manager"
+                    Description="View and edit the global OMT settings.xml"
+                    Target="[INSTALLDIR]omt-config-manager.exe"
+                    Icon="ProductIcon"
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}.config-manager"/>
+                </Shortcut>
+                <Shortcut Id="DiscoveryServerStartMenuShortcut"
+                    Name="Discovery Server"
+                    Description="Run an OMT discovery server for networks that block multicast"
+                    Target="[INSTALLDIR]omt-discovery-server-gui.exe"
+                    Icon="ProductIcon"
+                    WorkingDirectory="INSTALLDIR">
+                    <ShortcutProperty Key="System.AppUserModel.ID" Value="{{bundle_id}}.discovery-server"/>
+                </Shortcut>
                 <RemoveFolder Id="ApplicationProgramsFolder" On="uninstall"/>
                 <RegistryValue Root="HKCU" Key="Software\\{{manufacturer}}\\{{product_name}}" Name="Start Menu Shortcut" Type="integer" Value="1" KeyPath="yes"/>
            </Component>

--- a/apps/launcher/src/main.ts
+++ b/apps/launcher/src/main.ts
@@ -65,6 +65,14 @@ const TOOL_VISUALS: Record<string, ToolVisual> = {
     accent: "#f0c14a",
     icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="4" width="18" height="14" rx="2"/><circle cx="12" cy="11" r="3"/><path d="M8 21h8"/></svg>`,
   },
+  "config-manager": {
+    accent: "#5ad1a4",
+    icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 5h16v14H4z"/><path d="M8 9h8M8 12h8M8 15h5"/></svg>`,
+  },
+  "discovery-server": {
+    accent: "#c58cff",
+    icon: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M12 5v2M12 17v2M5 12h2M17 12h2M7 7l1.5 1.5M15.5 15.5L17 17M7 17l1.5-1.5M15.5 8.5L17 7"/></svg>`,
+  },
 };
 
 let state: LauncherState | null = null;

--- a/crates/suite-core/src/config.rs
+++ b/crates/suite-core/src/config.rs
@@ -234,6 +234,44 @@ impl Default for LauncherConfig {
     }
 }
 
+/// Discovery Server GUI preferences (`discovery-server.json`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiscoveryServerConfig {
+    /// Schema version.
+    pub schema_version: u32,
+    /// Listen address (`::` = dual-stack any, matching the official app).
+    pub bind: String,
+    /// Listen port (default 6399).
+    pub port: u16,
+}
+
+impl Default for DiscoveryServerConfig {
+    fn default() -> Self {
+        Self {
+            schema_version: 1,
+            bind: "::".into(),
+            port: 6399,
+        }
+    }
+}
+
+impl DiscoveryServerConfig {
+    /// Clamp bind/port into values the GUI and CLI accept.
+    pub fn sanitized(mut self) -> Self {
+        let trimmed = self.bind.trim();
+        self.bind = if trimmed.is_empty() {
+            "::".into()
+        } else {
+            trimmed.to_string()
+        };
+        if self.port == 0 {
+            self.port = 6399;
+        }
+        self
+    }
+}
+
 /// Resolve the suite config directory.
 pub fn config_dir() -> Result<PathBuf, ConfigError> {
     let dirs = ProjectDirs::from("lab", "Mikansei", "OMT Tools").ok_or(ConfigError::NoConfigDir)?;
@@ -288,6 +326,16 @@ pub fn load_launcher_config() -> Result<LauncherConfig, ConfigError> {
 /// Persist Launcher preferences.
 pub fn save_launcher_config(cfg: &LauncherConfig) -> Result<(), ConfigError> {
     save_json_file(&app_config_path("launcher")?, cfg)
+}
+
+/// Load Discovery Server GUI preferences.
+pub fn load_discovery_server_config() -> Result<DiscoveryServerConfig, ConfigError> {
+    load_json_file(&app_config_path("discovery-server")?)
+}
+
+/// Persist Discovery Server GUI preferences.
+pub fn save_discovery_server_config(cfg: &DiscoveryServerConfig) -> Result<(), ConfigError> {
+    save_json_file(&app_config_path("discovery-server")?, cfg)
 }
 
 fn load_json_file<T: DeserializeOwned + Default>(path: &Path) -> Result<T, ConfigError> {
@@ -438,5 +486,21 @@ mod tests {
             app_config_path("launcher").unwrap(),
             dir.join("launcher.json")
         );
+        assert_eq!(
+            app_config_path("discovery-server").unwrap(),
+            dir.join("discovery-server.json")
+        );
+    }
+
+    #[test]
+    fn sanitizes_discovery_server_bind_and_port() {
+        let parsed = DiscoveryServerConfig {
+            bind: "  ".into(),
+            port: 0,
+            ..Default::default()
+        }
+        .sanitized();
+        assert_eq!(parsed.bind, "::");
+        assert_eq!(parsed.port, 6399);
     }
 }

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -360,17 +360,57 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::English, "config.discovery") => "Discovery Server",
         (Language::Japanese, "config.discovery") => "Discovery Server",
         (Language::English, "config.discovery_hint") => {
-            "omt://host:port — leave empty to use DNS-SD"
+            "Example: omt://192.168.0.10:6399 — empty means DNS-SD (LAN multicast)"
         }
-        (Language::Japanese, "config.discovery_hint") => "omt://host:port — 空欄で DNS-SD を使用",
-        (Language::English, "config.clear_discovery") => "Use DNS-SD",
-        (Language::Japanese, "config.clear_discovery") => "DNS-SD を使う",
-        (Language::English, "config.port_start") => "Sender port start",
-        (Language::Japanese, "config.port_start") => "送信ポート開始",
-        (Language::English, "config.port_end") => "Sender port end",
-        (Language::Japanese, "config.port_end") => "送信ポート終了",
+        (Language::Japanese, "config.discovery_hint") => {
+            "例: omt://192.168.0.10:6399 — 空欄は DNS-SD（LAN のマルチキャスト検索）"
+        }
+        (Language::English, "config.clear_discovery") => "Clear field (use DNS-SD)",
+        (Language::Japanese, "config.clear_discovery") => "空欄にする（DNS-SD）",
+        (Language::English, "config.dns_sd_cleared") => {
+            "Cleared. Click Save to write an empty DiscoveryServer (DNS-SD)."
+        }
+        (Language::Japanese, "config.dns_sd_cleared") => {
+            "空欄にしました。保存すると DNS-SD になります。"
+        }
+        (Language::English, "config.dns_sd_already") => {
+            "Already empty — DNS-SD is already selected. Click Save if the file still has a URL."
+        }
+        (Language::Japanese, "config.dns_sd_already") => {
+            "すでに空欄です（DNS-SD）。ファイル側に URL が残っている場合は保存してください。"
+        }
+        (Language::English, "config.mode_dns_sd") => "Mode: DNS-SD",
+        (Language::Japanese, "config.mode_dns_sd") => "現在: DNS-SD",
+        (Language::English, "config.mode_unicast") => "Mode: unicast Discovery Server",
+        (Language::Japanese, "config.mode_unicast") => "現在: 指定サーバー",
+        (Language::English, "config.ph_discovery") => "omt://192.168.0.10:6399",
+        (Language::Japanese, "config.ph_discovery") => "omt://192.168.0.10:6399",
+        (Language::English, "config.port_range") => "Port range",
+        (Language::Japanese, "config.port_range") => "使用ポート範囲",
+        (Language::English, "config.port_range_sep") => "~",
+        (Language::Japanese, "config.port_range_sep") => "～",
+        (Language::English, "config.port_range_hint") => {
+            "TCP ports senders may bind (default 6400 ~ 6600)"
+        }
+        (Language::Japanese, "config.port_range_hint") => {
+            "送信側が使う TCP ポート範囲（既定 6400 ～ 6600）"
+        }
+        (Language::English, "config.port_start") => "Start",
+        (Language::Japanese, "config.port_start") => "開始",
+        (Language::English, "config.port_end") => "End",
+        (Language::Japanese, "config.port_end") => "終了",
+        (Language::English, "config.ph_port_start") => "6400",
+        (Language::Japanese, "config.ph_port_start") => "6400",
+        (Language::English, "config.ph_port_end") => "6600",
+        (Language::Japanese, "config.ph_port_end") => "6600",
         (Language::English, "config.extra") => "All keys",
         (Language::Japanese, "config.extra") => "すべてのキー",
+        (Language::English, "config.extra_hint") => {
+            "Extra XML tags. Key is the element name, value is the text inside."
+        }
+        (Language::Japanese, "config.extra_hint") => {
+            "追加の XML タグです。キーが要素名、値が中身です。"
+        }
         (Language::English, "config.add") => "Add",
         (Language::Japanese, "config.add") => "追加",
         (Language::English, "config.delete") => "Delete",
@@ -379,6 +419,18 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::Japanese, "config.key") => "キー",
         (Language::English, "config.value") => "Value",
         (Language::Japanese, "config.value") => "値",
+        (Language::English, "config.ph_key") => "VendorKey",
+        (Language::Japanese, "config.ph_key") => "VendorKey",
+        (Language::English, "config.ph_value") => "example",
+        (Language::Japanese, "config.ph_value") => "example",
+        (Language::English, "config.xml_preview") => "settings.xml (preview)",
+        (Language::Japanese, "config.xml_preview") => "settings.xml（プレビュー）",
+        (Language::English, "config.xml_preview_hint") => {
+            "Read-only live view of what Save will write"
+        }
+        (Language::Japanese, "config.xml_preview_hint") => {
+            "保存すると書き込まれる内容のリアルタイム表示（読み取り専用）"
+        }
         (Language::English, "config.saved") => "Saved",
         (Language::Japanese, "config.saved") => "保存しました",
         (Language::English, "config.reloaded") => "Reloaded",
@@ -407,10 +459,18 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::Japanese, "discovery.log") => "イベントログ",
         (Language::English, "discovery.clear_log") => "Clear",
         (Language::Japanese, "discovery.clear_log") => "クリア",
-        (Language::English, "discovery.bind_hint") => ":: for all interfaces (IPv6 dual-stack)",
-        (Language::Japanese, "discovery.bind_hint") => {
-            ":: ですべてのインターフェイス（IPv6 dual-stack）"
+        (Language::English, "discovery.bind_hint") => {
+            "Click a NIC below, or type :: / 0.0.0.0 / an address"
         }
+        (Language::Japanese, "discovery.bind_hint") => {
+            "下の NIC をクリックするか、:: / 0.0.0.0 / アドレスを入力"
+        }
+        (Language::English, "discovery.nic") => "Network interface",
+        (Language::Japanese, "discovery.nic") => "ネットワークインターフェイス",
+        (Language::English, "discovery.nic_all") => "All (::)",
+        (Language::Japanese, "discovery.nic_all") => "すべて (::)",
+        (Language::English, "discovery.nic_all_v4") => "All IPv4 (0.0.0.0)",
+        (Language::Japanese, "discovery.nic_all_v4") => "すべて IPv4 (0.0.0.0)",
 
         _ => "???",
     }
@@ -445,7 +505,11 @@ mod tests {
             "patterns.start",
             "patterns.restart_required",
             "config.path",
+            "config.port_range",
+            "config.xml_preview",
+            "config.ph_discovery",
             "discovery.start",
+            "discovery.nic",
         ];
         for key in keys {
             assert_ne!(t(Language::English, key), key, "missing en key {key}");

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -111,6 +111,20 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::Japanese, "tool.screen_capture.desc") => {
             "デスクトップをキャプチャしてOMT送出（プレビュー）"
         }
+        (Language::English, "tool.config_manager") => "Config Manager",
+        (Language::Japanese, "tool.config_manager") => "Config Manager",
+        (Language::English, "tool.config_manager.desc") => {
+            "View and edit the global OMT settings.xml"
+        }
+        (Language::Japanese, "tool.config_manager.desc") => "OMT全体の settings.xml を表示・編集",
+        (Language::English, "tool.discovery_server") => "Discovery Server",
+        (Language::Japanese, "tool.discovery_server") => "Discovery Server",
+        (Language::English, "tool.discovery_server.desc") => {
+            "Run an OMT discovery server for networks that block multicast"
+        }
+        (Language::Japanese, "tool.discovery_server.desc") => {
+            "マルチキャストが使えないネットワーク向けのOMT Discovery Server"
+        }
         (Language::English, "tool.unavailable") => "Not installed",
         (Language::Japanese, "tool.unavailable") => "未インストール",
 
@@ -336,6 +350,68 @@ pub fn t(lang: Language, key: &str) -> &'static str {
             "目標FPSを維持できません — 品質を下げてください"
         }
 
+        // Config Manager
+        (Language::English, "config.path") => "File",
+        (Language::Japanese, "config.path") => "ファイル",
+        (Language::English, "config.reload") => "Reload",
+        (Language::Japanese, "config.reload") => "再読込",
+        (Language::English, "config.reveal") => "Show in folder",
+        (Language::Japanese, "config.reveal") => "フォルダーで表示",
+        (Language::English, "config.discovery") => "Discovery Server",
+        (Language::Japanese, "config.discovery") => "Discovery Server",
+        (Language::English, "config.discovery_hint") => {
+            "omt://host:port — leave empty to use DNS-SD"
+        }
+        (Language::Japanese, "config.discovery_hint") => "omt://host:port — 空欄で DNS-SD を使用",
+        (Language::English, "config.clear_discovery") => "Use DNS-SD",
+        (Language::Japanese, "config.clear_discovery") => "DNS-SD を使う",
+        (Language::English, "config.port_start") => "Sender port start",
+        (Language::Japanese, "config.port_start") => "送信ポート開始",
+        (Language::English, "config.port_end") => "Sender port end",
+        (Language::Japanese, "config.port_end") => "送信ポート終了",
+        (Language::English, "config.extra") => "All keys",
+        (Language::Japanese, "config.extra") => "すべてのキー",
+        (Language::English, "config.add") => "Add",
+        (Language::Japanese, "config.add") => "追加",
+        (Language::English, "config.delete") => "Delete",
+        (Language::Japanese, "config.delete") => "削除",
+        (Language::English, "config.key") => "Key",
+        (Language::Japanese, "config.key") => "キー",
+        (Language::English, "config.value") => "Value",
+        (Language::Japanese, "config.value") => "値",
+        (Language::English, "config.saved") => "Saved",
+        (Language::Japanese, "config.saved") => "保存しました",
+        (Language::English, "config.reloaded") => "Reloaded",
+        (Language::Japanese, "config.reloaded") => "再読込しました",
+
+        // Discovery Server GUI
+        (Language::English, "discovery.bind") => "Bind address",
+        (Language::Japanese, "discovery.bind") => "バインドアドレス",
+        (Language::English, "discovery.port") => "Port",
+        (Language::Japanese, "discovery.port") => "ポート",
+        (Language::English, "discovery.start") => "Start",
+        (Language::Japanese, "discovery.start") => "開始",
+        (Language::English, "discovery.stop") => "Stop",
+        (Language::Japanese, "discovery.stop") => "停止",
+        (Language::English, "discovery.running") => "Running",
+        (Language::Japanese, "discovery.running") => "稼働中",
+        (Language::English, "discovery.stopped") => "Stopped",
+        (Language::Japanese, "discovery.stopped") => "停止中",
+        (Language::English, "discovery.peers") => "Clients",
+        (Language::Japanese, "discovery.peers") => "クライアント",
+        (Language::English, "discovery.sources") => "Registered sources",
+        (Language::Japanese, "discovery.sources") => "登録ソース",
+        (Language::English, "discovery.none") => "None",
+        (Language::Japanese, "discovery.none") => "なし",
+        (Language::English, "discovery.log") => "Event log",
+        (Language::Japanese, "discovery.log") => "イベントログ",
+        (Language::English, "discovery.clear_log") => "Clear",
+        (Language::Japanese, "discovery.clear_log") => "クリア",
+        (Language::English, "discovery.bind_hint") => ":: for all interfaces (IPv6 dual-stack)",
+        (Language::Japanese, "discovery.bind_hint") => {
+            ":: ですべてのインターフェイス（IPv6 dual-stack）"
+        }
+
         _ => "???",
     }
 }
@@ -363,9 +439,13 @@ mod tests {
             "simd",
             "tool.studio_monitor",
             "tool.test_patterns",
+            "tool.config_manager",
+            "tool.discovery_server",
             "monitor.stalled",
             "patterns.start",
             "patterns.restart_required",
+            "config.path",
+            "discovery.start",
         ];
         for key in keys {
             assert_ne!(t(Language::English, key), key, "missing en key {key}");

--- a/crates/suite-core/src/lib.rs
+++ b/crates/suite-core/src/lib.rs
@@ -12,9 +12,10 @@ mod theme;
 mod version;
 
 pub use config::{
-    LauncherConfig, StudioMonitorConfig, SuiteConfig, TestPatternsConfig, TestPatternsQuality,
-    app_config_path, config_dir, config_path, load_config, load_launcher_config,
-    load_studio_monitor_config, load_test_patterns_config, save_config, save_launcher_config,
+    DiscoveryServerConfig, LauncherConfig, StudioMonitorConfig, SuiteConfig, TestPatternsConfig,
+    TestPatternsQuality, app_config_path, config_dir, config_path, load_config,
+    load_discovery_server_config, load_launcher_config, load_studio_monitor_config,
+    load_test_patterns_config, save_config, save_discovery_server_config, save_launcher_config,
     save_studio_monitor_config, save_test_patterns_config,
 };
 #[cfg(feature = "egui-fonts")]

--- a/crates/suite-core/src/version.rs
+++ b/crates/suite-core/src/version.rs
@@ -15,6 +15,10 @@ pub enum ToolId {
     TestPatterns,
     /// Screen Capture sender (optional / preview).
     ScreenCapture,
+    /// Global `settings.xml` editor.
+    ConfigManager,
+    /// Discovery Server GUI.
+    DiscoveryServer,
 }
 
 impl ToolId {
@@ -24,6 +28,8 @@ impl ToolId {
             Self::StudioMonitor => "omt-studio-monitor",
             Self::TestPatterns => "omt-test-patterns",
             Self::ScreenCapture => "omt-screen-capture",
+            Self::ConfigManager => "omt-config-manager",
+            Self::DiscoveryServer => "omt-discovery-server-gui",
         }
     }
 
@@ -33,6 +39,8 @@ impl ToolId {
             Self::StudioMonitor => "tool.studio_monitor",
             Self::TestPatterns => "tool.test_patterns",
             Self::ScreenCapture => "tool.screen_capture",
+            Self::ConfigManager => "tool.config_manager",
+            Self::DiscoveryServer => "tool.discovery_server",
         }
     }
 
@@ -42,12 +50,20 @@ impl ToolId {
             Self::StudioMonitor => "tool.studio_monitor.desc",
             Self::TestPatterns => "tool.test_patterns.desc",
             Self::ScreenCapture => "tool.screen_capture.desc",
+            Self::ConfigManager => "tool.config_manager.desc",
+            Self::DiscoveryServer => "tool.discovery_server.desc",
         }
     }
 
     /// All known tools in launcher order.
     pub const fn all() -> &'static [ToolId] {
-        &[Self::StudioMonitor, Self::TestPatterns, Self::ScreenCapture]
+        &[
+            Self::StudioMonitor,
+            Self::TestPatterns,
+            Self::ConfigManager,
+            Self::DiscoveryServer,
+            Self::ScreenCapture,
+        ]
     }
 
     /// Start Menu / Applications / `.desktop` display name (English, OS chrome).
@@ -56,6 +72,8 @@ impl ToolId {
             Self::StudioMonitor => "Studio Monitor",
             Self::TestPatterns => "Test Patterns",
             Self::ScreenCapture => "Screen Capture",
+            Self::ConfigManager => "Config Manager",
+            Self::DiscoveryServer => "Discovery Server",
         }
     }
 
@@ -65,6 +83,8 @@ impl ToolId {
             Self::StudioMonitor => "OMT Studio Monitor",
             Self::TestPatterns => "OMT Test Patterns",
             Self::ScreenCapture => "OMT Screen Capture",
+            Self::ConfigManager => "OMT Config Manager",
+            Self::DiscoveryServer => "OMT Discovery Server",
         }
     }
 
@@ -74,6 +94,8 @@ impl ToolId {
             Self::StudioMonitor => "studio-monitor",
             Self::TestPatterns => "test-patterns",
             Self::ScreenCapture => "screen-capture",
+            Self::ConfigManager => "config-manager",
+            Self::DiscoveryServer => "discovery-server",
         }
     }
 }
@@ -121,6 +143,18 @@ pub fn suite_manifest() -> SuiteManifest {
                 enabled: true,
             },
             ToolInfo {
+                id: ToolId::ConfigManager,
+                version: SUITE_VERSION.to_string(),
+                binary: ToolId::ConfigManager.binary_name().to_string(),
+                enabled: true,
+            },
+            ToolInfo {
+                id: ToolId::DiscoveryServer,
+                version: SUITE_VERSION.to_string(),
+                binary: ToolId::DiscoveryServer.binary_name().to_string(),
+                enabled: true,
+            },
+            ToolInfo {
                 id: ToolId::ScreenCapture,
                 version: SUITE_VERSION.to_string(),
                 binary: ToolId::ScreenCapture.binary_name().to_string(),
@@ -147,6 +181,16 @@ mod tests {
             m.tools
                 .iter()
                 .any(|t| t.id == ToolId::TestPatterns && t.enabled)
+        );
+        assert!(
+            m.tools
+                .iter()
+                .any(|t| t.id == ToolId::ConfigManager && t.enabled)
+        );
+        assert!(
+            m.tools
+                .iter()
+                .any(|t| t.id == ToolId::DiscoveryServer && t.enabled)
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -7,11 +7,14 @@
     "dev": "bun run --cwd apps/launcher dev",
     "build": "bun run --cwd apps/launcher build",
     "tauri": "bun run --cwd apps/launcher tauri",
-    "tools:build": "cargo build -p omt-studio-monitor -p omt-test-patterns",
-    "tools:build:release": "cargo build --release -p omt-studio-monitor -p omt-test-patterns",
+    "tools:build": "cargo build -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server",
+    "tools:build:release": "cargo build --release -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server",
     "tools:run:studio-monitor": "cargo run -p omt-studio-monitor",
     "tools:run:studio-monitor:release": "cargo run --release -p omt-studio-monitor",
     "tools:run:test-patterns": "cargo run -p omt-test-patterns",
-    "tools:run:test-patterns:release": "cargo run --release -p omt-test-patterns"
+    "tools:run:test-patterns:release": "cargo run --release -p omt-test-patterns",
+    "tools:run:config-manager": "cargo run -p omt-config-manager",
+    "tools:run:discovery-server": "cargo run -p omt-discovery-server --bin omt-discovery-server",
+    "tools:run:discovery-server-gui": "cargo run -p omt-discovery-server --bin omt-discovery-server-gui"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "bun run --cwd apps/launcher build",
     "tauri": "bun run --cwd apps/launcher tauri",
     "tools:build": "cargo build -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server",
+    "tools:sidecars:dev": "bun scripts/prepare-dev-sidecars.js",
     "tools:build:release": "cargo build --release -p omt-studio-monitor -p omt-test-patterns -p omt-config-manager -p omt-discovery-server",
     "tools:run:studio-monitor": "cargo run -p omt-studio-monitor",
     "tools:run:studio-monitor:release": "cargo run --release -p omt-studio-monitor",

--- a/scripts/ensure-sidecar-placeholders.ps1
+++ b/scripts/ensure-sidecar-placeholders.ps1
@@ -26,3 +26,6 @@ function Ensure-One([string]$Name) {
 
 Ensure-One omt-studio-monitor
 Ensure-One omt-test-patterns
+Ensure-One omt-config-manager
+Ensure-One omt-discovery-server-gui
+Ensure-One omt-discovery-server

--- a/scripts/ensure-sidecar-placeholders.ps1
+++ b/scripts/ensure-sidecar-placeholders.ps1
@@ -1,5 +1,6 @@
-# Ensure Tauri externalBin placeholders exist for the host triple.
-# Real binaries should be produced via prepare-sidecars after a release build.
+# Ensure Tauri externalBin paths exist for the host triple.
+# Prefer a real debug/release tool. Never copy cmd.exe — that used to make
+# `tauri dev` launch a console instead of Config Manager / Discovery Server.
 
 param(
     [string]$Target = (rustc -vV | Select-String '^host:').ToString().Split(' ')[1]
@@ -9,18 +10,37 @@ $Root = Split-Path -Parent $PSScriptRoot
 $Out = Join-Path $Root "apps\launcher\src-tauri\binaries"
 New-Item -ItemType Directory -Force -Path $Out | Out-Null
 
+$CmdExe = Join-Path $env:WINDIR "System32\cmd.exe"
+$CmdLen = if (Test-Path $CmdExe) { (Get-Item $CmdExe).Length } else { 0 }
+
+function Test-CmdClone([string]$Path) {
+    if (-not (Test-Path $Path)) { return $false }
+    if ($CmdLen -le 0) { return $false }
+    return ((Get-Item $Path).Length -eq $CmdLen)
+}
+
+function Write-Stub([string]$Path) {
+    # Minimal MZ bytes so tauri-build can resolve externalBin during `cargo check`.
+    [System.IO.File]::WriteAllBytes($Path, [byte[]](0x4D, 0x5A))
+}
+
 function Ensure-One([string]$Name) {
     $dst = Join-Path $Out "$Name-$Target.exe"
-    if (Test-Path $dst) { return }
     $release = Join-Path $Root "target\release\$Name.exe"
     $debug = Join-Path $Root "target\debug\$Name.exe"
-    if (Test-Path $release) {
+
+    if ((Test-Path $release) -and -not (Test-CmdClone $release)) {
         Copy-Item $release $dst -Force
-    } elseif (Test-Path $debug) {
+        return
+    }
+    if ((Test-Path $debug) -and -not (Test-CmdClone $debug)) {
         Copy-Item $debug $dst -Force
-    } else {
-        Copy-Item "$env:WINDIR\System32\cmd.exe" $dst -Force
-        Write-Warning "placeholder sidecar for $Name (build the real tool before packaging)"
+        return
+    }
+
+    if (-not (Test-Path $dst) -or (Test-CmdClone $dst)) {
+        Write-Stub $dst
+        Write-Warning "sidecar stub for $Name (build the real tool before tauri dev/packaging)"
     }
 }
 

--- a/scripts/prepare-dev-sidecars.js
+++ b/scripts/prepare-dev-sidecars.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+// Build sidecar tools and copy them into apps/launcher/src-tauri/binaries
+// with the host target-triple suffix that Tauri's externalBin expects.
+// Replaces cmd.exe placeholders that used to be copied by ensure-sidecar-placeholders.
+
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, statSync, unlinkSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const names = [
+  "omt-studio-monitor",
+  "omt-test-patterns",
+  "omt-config-manager",
+  "omt-discovery-server-gui",
+  "omt-discovery-server",
+];
+
+function hostTriple() {
+  const out = spawnSync("rustc", ["-vV"], { encoding: "utf8" });
+  const line = (out.stdout ?? "").split(/\r?\n/).find((l) => l.startsWith("host:"));
+  if (!line) {
+    throw new Error("could not read rustc host triple");
+  }
+  return line.split(/\s+/)[1];
+}
+
+function cmdExePath() {
+  const windir = process.env.WINDIR ?? "C:\\Windows";
+  return join(windir, "System32", "cmd.exe");
+}
+
+function isCmdClone(path) {
+  if (process.platform !== "win32" || !existsSync(path)) {
+    return false;
+  }
+  const cmd = cmdExePath();
+  if (!existsSync(cmd)) {
+    return false;
+  }
+  return statSync(path).size === statSync(cmd).size;
+}
+
+function isStub(path) {
+  if (!existsSync(path)) {
+    return true;
+  }
+  return statSync(path).size < 64 * 1024;
+}
+
+const windows = process.platform === "win32";
+const debugDir = join(root, "target", "debug");
+
+for (const name of names) {
+  const debugBin = join(debugDir, windows ? `${name}.exe` : name);
+  if (isCmdClone(debugBin) || (existsSync(debugBin) && isStub(debugBin))) {
+    unlinkSync(debugBin);
+  }
+}
+
+const cargo = spawnSync(
+  "cargo",
+  [
+    "build",
+    "-p",
+    "omt-studio-monitor",
+    "-p",
+    "omt-test-patterns",
+    "-p",
+    "omt-config-manager",
+    "-p",
+    "omt-discovery-server",
+  ],
+  { cwd: root, stdio: "inherit", shell: windows },
+);
+if (cargo.status !== 0) {
+  process.exit(cargo.status ?? 1);
+}
+
+const triple = hostTriple();
+const destDir = join(root, "apps", "launcher", "src-tauri", "binaries");
+mkdirSync(destDir, { recursive: true });
+
+for (const name of names) {
+  const src = join(debugDir, windows ? `${name}.exe` : name);
+  if (!existsSync(src) || isCmdClone(src) || isStub(src)) {
+    console.warn(`skip ${name}: missing or placeholder at ${src}`);
+    continue;
+  }
+  const dst = join(destDir, windows ? `${name}-${triple}.exe` : `${name}-${triple}`);
+  copyFileSync(src, dst);
+  console.log(`prepared ${name}`);
+}

--- a/scripts/prepare-sidecars.ps1
+++ b/scripts/prepare-sidecars.ps1
@@ -24,3 +24,6 @@ function Copy-One([string]$Name) {
 
 Copy-One omt-studio-monitor
 Copy-One omt-test-patterns
+Copy-One omt-config-manager
+Copy-One omt-discovery-server-gui
+Copy-One omt-discovery-server

--- a/scripts/prepare-sidecars.sh
+++ b/scripts/prepare-sidecars.sh
@@ -30,3 +30,6 @@ copy_one() {
 
 copy_one omt-studio-monitor
 copy_one omt-test-patterns
+copy_one omt-config-manager
+copy_one omt-discovery-server-gui
+copy_one omt-discovery-server


### PR DESCRIPTION
## Summary
- Ship a GPUI **Config Manager** that loads, validates, and saves the global OMT `settings.xml` (known keys plus unknown vendor keys).
- Ship **Discovery Server** as a clap CLI (official `OMTDiscoveryServer` behavior: dual-stack `[::]:6399`, Ctrl-C shutdown) and a GPUI console (bind/port, start/stop, peers, registered sources, event log).
- Register the GUIs in the launcher, sidecar packaging, Start Menu / desktop entries, and CI/release builds. The CLI is installed as a sidecar but is not a launcher card.

Depends on [openmediatransport-rs#26](https://github.com/MikanseiLaboratory/openmediatransport-rs/pull/26) (already CI-green). `Cargo.toml` pins `openmediatransport` to that commit.

Closes #17
Closes #18

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy` on suite-core, media crates, and all GUI/CLI tools (`-D warnings`)
- [x] `cargo test` for suite-core, omt-media, pattern-generator, monitor-bench, capture-spike, omt-config-manager, omt-discovery-server
- [x] `cargo check -p omt-launcher` with sidecar placeholders
- [ ] After #26 is merged, optionally retarget the git dep to `main` (the pinned commit remains valid)
