### PR TITLE
Stop senders by closing TCP and deregistering Discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "openmediatransport"
 version = "0.1.0"
-source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=221f3e2f200f754dbfbe63997c75e2e90d3bc47d#221f3e2f200f754dbfbe63997c75e2e90d3bc47d"
+source = "git+https://github.com/MikanseiLaboratory/openmediatransport-rs?rev=2a0a9d3113e44d7bc3fb72468f05d9e8215b4b6f#2a0a9d3113e44d7bc3fb72468f05d9e8215b4b6f"
 dependencies = [
  "bytes",
  "mdns-sd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ suite-core = { path = "crates/suite-core" }
 omt-media = { path = "crates/omt-media" }
 pattern-generator = { path = "crates/pattern-generator" }
 monitor-bench = { path = "crates/monitor-bench" }
-openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "221f3e2f200f754dbfbe63997c75e2e90d3bc47d", features = ["tokio"] }
+openmediatransport = { git = "https://github.com/MikanseiLaboratory/openmediatransport-rs", rev = "2a0a9d3113e44d7bc3fb72468f05d9e8215b4b6f", features = ["tokio"] }
 gpui = "0.2.2"
 vmx = { git = "https://github.com/MikanseiLaboratory/vmx-rs" }
 anyhow = "1"

--- a/crates/omt-media/src/receive.rs
+++ b/crates/omt-media/src/receive.rs
@@ -530,6 +530,11 @@ async fn apply_connect(
     playout: &mut Playout,
 ) {
     *latest.error.lock() = None;
+    // Tear down the previous session before clearing UI state so decode threads
+    // cannot publish leftover frames into the new selection.
+    if let Some(old) = receiver.take() {
+        old.disconnect();
+    }
     // Close the prep identity gate and drop leftover pixels from the previous
     // source before opening the new session. Setting `url` only after connect
     // succeeds prevents republishing the old source under the new selection.
@@ -543,9 +548,6 @@ async fn apply_connect(
     playout.reset();
     publish_buffer_delays(latest, playout);
     stall.lock().reset();
-    if let Some(old) = receiver.take() {
-        old.disconnect();
-    }
     *latest.session_state.lock() = SessionState::Connecting;
     let url = opts.url.clone();
     match open_receiver(opts).await {

--- a/crates/omt-media/src/send.rs
+++ b/crates/omt-media/src/send.rs
@@ -134,7 +134,9 @@ pub struct SendSession {
     audio: Arc<Mutex<AudioToneConfig>>,
     animate: Arc<AtomicBool>,
     content_epoch: Arc<AtomicU64>,
-    sender: Arc<Mutex<Sender>>,
+    sender: Option<Arc<Mutex<Sender>>>,
+    discovery: Option<Discovery>,
+    source_name: String,
     fps_n: Arc<AtomicI32>,
     fps_d: Arc<AtomicI32>,
     frame_buffer_frames: Arc<AtomicU32>,
@@ -164,18 +166,17 @@ impl SendSession {
             s.set_quality(config.quality);
         }
         let port = sender.lock().port();
-        {
-            let name = config.name.clone();
-            // DNS-SD register is blocking; keep advertisement alive via leak (same as before).
+        let source_name = config.name.clone();
+        let discovery = {
+            let name = source_name.clone();
             runtime::handle()
                 .block_on(runtime::spawn_blocking(move || {
                     let mut discovery = Discovery::new()?;
                     discovery.register(&name, port)?;
-                    std::mem::forget(discovery);
-                    Ok::<(), OmtError>(())
+                    Ok::<_, OmtError>(discovery)
                 }))
-                .map_err(|e| OmtError::Discovery(e.to_string()))??;
-        }
+                .map_err(|e| OmtError::Discovery(e.to_string()))??
+        };
 
         let running = Arc::new(AtomicBool::new(true));
         let stats = Arc::new(Mutex::new(SendStats {
@@ -232,7 +233,9 @@ impl SendSession {
             audio,
             animate,
             content_epoch,
-            sender,
+            sender: Some(sender),
+            discovery: Some(discovery),
+            source_name,
             fps_n,
             fps_d,
             frame_buffer_frames,
@@ -269,7 +272,9 @@ impl SendSession {
 
     /// Hot-update encoding quality without tearing down the sender.
     pub fn set_quality(&self, quality: Quality) {
-        self.sender.lock().set_quality(quality);
+        if let Some(sender) = self.sender.as_ref() {
+            sender.lock().set_quality(quality);
+        }
     }
 
     /// Hot-update output frame rate. Pacing and per-frame metadata follow.
@@ -286,7 +291,8 @@ impl SendSession {
         );
     }
 
-    /// Stop tasks / threads.
+    /// Stop tasks / threads, close TCP peers, and deregister Discovery
+    /// (`<Removed>True</Removed>` / DNS-SD unregister).
     pub fn stop(&mut self) {
         self.running.store(false, Ordering::Relaxed);
         if let Some(join) = self.video_join.take() {
@@ -295,6 +301,11 @@ impl SendSession {
         if let Some(join) = self.audio_join.take() {
             let _ = join.join();
         }
+        // libomtnet OMTSend.Dispose: DeregisterAddress, then close listener/channels.
+        if let Some(mut discovery) = self.discovery.take() {
+            let _ = discovery.deregister(&self.source_name);
+        }
+        drop(self.sender.take());
     }
 }
 


### PR DESCRIPTION
## Summary
- Test Patterns no longer leaks Discovery via `mem::forget`. Stop now deregisters the source then drops the sender, matching libomtnet `OMTSend.Dispose`. Fixes #37.
- Studio Monitor source switches disconnect the previous receive session before clearing frames, so leftover pixels cannot land on the new selection.
- Pair with the openmediatransport-rs disconnect PR for the second-source receive stall; bump the git `rev` after that lands.

## Test plan
- [ ] Test Patterns: Start, then Stop — source leaves Studio Monitor / discovery within a few seconds
- [ ] Test Patterns: Stop then Start again — a new advertisement appears and receives work
- [ ] Studio Monitor: switch sources without a frozen previous frame