### PR TITLE
Add launcher update checks and bump to v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -314,7 +314,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2248,7 +2248,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2687,7 +2687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5170,7 +5170,7 @@ dependencies = [
 
 [[package]]
 name = "monitor-bench"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5209,7 +5209,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6064,7 +6064,7 @@ dependencies = [
 
 [[package]]
 name = "omt-config-manager"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6075,7 +6075,7 @@ dependencies = [
 
 [[package]]
 name = "omt-discovery-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "omt-launcher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6096,13 +6096,14 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
  "tauri-plugin-updater",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "omt-media"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cpal",
@@ -6117,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "omt-studio-monitor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6131,7 +6132,7 @@ dependencies = [
 
 [[package]]
 name = "omt-test-patterns"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -6370,7 +6371,7 @@ dependencies = [
 
 [[package]]
 name = "pattern-generator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "image",
  "omt-media",
@@ -6896,7 +6897,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7451,7 +7452,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7517,7 +7518,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8227,7 +8228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8321,7 +8322,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8441,7 +8442,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suite-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "directories",
@@ -8930,6 +8931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9072,7 +9083,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9583,7 +9594,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9642,7 +9653,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10627,7 +10638,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OMT Tools
 
 [![CI](https://github.com/MikanseiLaboratory/omt-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/MikanseiLaboratory/omt-tools/actions/workflows/ci.yml)
-[Latest release](https://github.com/MikanseiLaboratory/omt-tools/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/MikanseiLaboratory/omt-tools?label=Latest%20release)](https://github.com/MikanseiLaboratory/omt-tools/releases/latest)
 
 Open Media Transport production utilities inspired by NDI Tools.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 
 Open Media Transport production utilities inspired by NDI Tools.
 
-<img width="864" height="571" alt="image" src="https://github.com/user-attachments/assets/80605b83-effc-4733-b96a-80b34c46e3ce" />
+<img width="907" height="703" alt="image" src="https://github.com/user-attachments/assets/e3900c36-cf5b-47fe-8dc0-174d53682840" />
+
 
 
 ## Suite contents

--- a/apps/launcher/bun.lock
+++ b/apps/launcher/bun.lock
@@ -6,6 +6,8 @@
       "dependencies": {
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
       },
       "devDependencies": {
         "@tauri-apps/cli": "^2",
@@ -146,6 +148,10 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
     "@tauri-apps/plugin-opener": ["@tauri-apps/plugin-opener@2.5.4", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ=="],
+
+    "@tauri-apps/plugin-process": ["@tauri-apps/plugin-process@2.3.1", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA=="],
+
+    "@tauri-apps/plugin-updater": ["@tauri-apps/plugin-updater@2.10.1", "", { "dependencies": { "@tauri-apps/api": "^2.10.1" } }, "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 

--- a/apps/launcher/index.html
+++ b/apps/launcher/index.html
@@ -56,7 +56,7 @@
       <footer class="footer">
         <div class="footer-left">
           <span id="footer-version-label">Version</span>
-          <span id="footer-version">0.1.0</span>
+          <span id="footer-version">0.1.1</span>
         </div>
         <a class="footer-center" id="footer-site" href="https://github.com/MikanseiLaboratory/omt-tools" target="_blank" rel="noreferrer">
           github.com/MikanseiLaboratory/omt-tools
@@ -70,9 +70,11 @@
           <div class="settings-row">
             <div>
               <div class="settings-kicker" id="version-label">Version</div>
-              <div class="settings-version" id="suite-version">0.1.0</div>
+              <div class="settings-version" id="suite-version">0.1.1</div>
             </div>
           </div>
+          <button type="button" class="primary-btn" id="check-update">Check for updates</button>
+          <p class="settings-note" id="update-status"></p>
           <pre class="settings-manifest" id="manifest-tools"></pre>
         </div>
 
@@ -102,6 +104,17 @@
           <p class="settings-status" id="settings-status"></p>
         </div>
       </aside>
+
+      <div class="dialog-backdrop hidden" id="update-backdrop"></div>
+      <div class="update-dialog hidden" id="update-dialog" role="dialog" aria-modal="true" aria-labelledby="update-title">
+        <h2 id="update-title">Update available</h2>
+        <p id="update-body"></p>
+        <pre class="update-notes hidden" id="update-notes"></pre>
+        <div class="dialog-actions">
+          <button type="button" class="primary-btn" id="update-later">Later</button>
+          <button type="button" class="primary-btn" id="update-confirm">Update</button>
+        </div>
+      </div>
 
       <p class="toast hidden" id="status" role="status"></p>
     </div>

--- a/apps/launcher/package.json
+++ b/apps/launcher/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omt-tools-launcher",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "packageManager": "bun@1.2.19",
   "scripts": {
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2",
-    "@tauri-apps/plugin-opener": "^2"
+    "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2",

--- a/apps/launcher/src-tauri/Cargo.toml
+++ b/apps/launcher/src-tauri/Cargo.toml
@@ -24,5 +24,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 thiserror = "2"

--- a/apps/launcher/src-tauri/capabilities/default.json
+++ b/apps/launcher/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "opener:default",
+    "process:allow-restart",
     "updater:default"
   ]
 }

--- a/apps/launcher/src-tauri/src/lib.rs
+++ b/apps/launcher/src-tauri/src/lib.rs
@@ -54,6 +54,15 @@ struct Labels {
     theme_system: String,
     unavailable: String,
     simd: String,
+    update_check: String,
+    update_checking: String,
+    update_available_title: String,
+    update_available_body: String,
+    update_install: String,
+    update_later: String,
+    update_none: String,
+    update_installing: String,
+    update_failed: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -81,6 +90,15 @@ fn labels(lang: Language) -> Labels {
         theme_system: t(lang, "theme.system").to_string(),
         unavailable: t(lang, "tool.unavailable").to_string(),
         simd: t(lang, "simd").to_string(),
+        update_check: t(lang, "update.check").to_string(),
+        update_checking: t(lang, "update.checking").to_string(),
+        update_available_title: t(lang, "update.available.title").to_string(),
+        update_available_body: t(lang, "update.available.body").to_string(),
+        update_install: t(lang, "update.install").to_string(),
+        update_later: t(lang, "update.later").to_string(),
+        update_none: t(lang, "update.none").to_string(),
+        update_installing: t(lang, "update.installing").to_string(),
+        update_failed: t(lang, "update.failed").to_string(),
     }
 }
 
@@ -193,6 +211,7 @@ fn native_menu<R: tauri::Runtime>(
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .menu(native_menu)
         .setup(|app| {

--- a/apps/launcher/src-tauri/tauri.conf.json
+++ b/apps/launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OMT Tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "lab.mikansei.omt-tools",
   "build": {
     "beforeDevCommand": "bun run dev:frontend",

--- a/apps/launcher/src/main.ts
+++ b/apps/launcher/src/main.ts
@@ -1,6 +1,8 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { relaunch } from "@tauri-apps/plugin-process";
+import { check, type Update } from "@tauri-apps/plugin-updater";
 
 const DOCS_URL = "https://github.com/MikanseiLaboratory/omt-tools#readme";
 
@@ -31,6 +33,15 @@ type Labels = {
   themeSystem: string;
   unavailable: string;
   simd: string;
+  updateCheck: string;
+  updateChecking: string;
+  updateAvailableTitle: string;
+  updateAvailableBody: string;
+  updateInstall: string;
+  updateLater: string;
+  updateNone: string;
+  updateInstalling: string;
+  updateFailed: string;
 };
 
 type LauncherState = {
@@ -73,6 +84,10 @@ const TOOL_VISUALS: Record<string, ToolVisual> = {
 
 let state: LauncherState | null = null;
 let settingsOpen = false;
+let updateDialogOpen = false;
+let checkingUpdate = false;
+let installingUpdate = false;
+let pendingUpdate: Update | null = null;
 /** toolId -> clearTimeout handle while launch feedback is visible */
 const launchingTimers = new Map<string, number>();
 /** Keep tile feedback after spawn() returns — window paint usually lags. */
@@ -104,6 +119,10 @@ function renderLabels(labels: Labels) {
   $("footer-version-label").textContent = labels.version;
   $("simd-label").textContent = labels.simd;
   $("save-settings").textContent = labels.save;
+  $("check-update").textContent = labels.updateCheck;
+  $("update-title").textContent = labels.updateAvailableTitle;
+  $("update-later").textContent = labels.updateLater;
+  $("update-confirm").textContent = labels.updateInstall;
 
   const themeSelect = $("theme-select") as HTMLSelectElement;
   themeSelect.options[0].text = labels.themeSystem;
@@ -221,6 +240,89 @@ function setSettingsOpen(open: boolean) {
   $("settings-btn").setAttribute("aria-expanded", open ? "true" : "false");
 }
 
+function formatLabel(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (_, key: string) => vars[key] ?? "");
+}
+
+function setUpdateDialogOpen(open: boolean) {
+  updateDialogOpen = open;
+  $("update-dialog").classList.toggle("hidden", !open);
+  $("update-backdrop").classList.toggle("hidden", !open);
+  if (!open && !installingUpdate) {
+    pendingUpdate = null;
+  }
+}
+
+function showUpdateDialog(update: Update) {
+  if (!state) return;
+  pendingUpdate = update;
+  const confirmBtn = $("update-confirm") as HTMLButtonElement;
+  const laterBtn = $("update-later") as HTMLButtonElement;
+  confirmBtn.disabled = false;
+  laterBtn.disabled = false;
+  $("update-title").textContent = state.labels.updateAvailableTitle;
+  $("update-body").textContent = formatLabel(state.labels.updateAvailableBody, {
+    version: update.version,
+  });
+  const notes = (update.body ?? "").trim();
+  const notesEl = $("update-notes");
+  notesEl.textContent = notes;
+  notesEl.classList.toggle("hidden", !notes);
+  setSettingsOpen(false);
+  setUpdateDialogOpen(true);
+}
+
+async function checkForUpdate(origin: "auto" | "manual") {
+  if (!state || checkingUpdate || installingUpdate || updateDialogOpen) return;
+  checkingUpdate = true;
+  const statusEl = $("update-status");
+  const checkBtn = $("check-update") as HTMLButtonElement;
+  if (origin === "manual") {
+    statusEl.textContent = state.labels.updateChecking;
+    checkBtn.disabled = true;
+  }
+  try {
+    const update = await check();
+    if (!update) {
+      if (origin === "manual") {
+        statusEl.textContent = state.labels.updateNone;
+      }
+      return;
+    }
+    if (origin === "manual") {
+      statusEl.textContent = "";
+    }
+    showUpdateDialog(update);
+  } catch (err) {
+    if (origin === "manual") {
+      statusEl.textContent = `${state.labels.updateFailed} ${String(err)}`;
+    }
+  } finally {
+    checkingUpdate = false;
+    checkBtn.disabled = false;
+  }
+}
+
+async function installPendingUpdate() {
+  if (!pendingUpdate || !state || installingUpdate) return;
+  installingUpdate = true;
+  const confirmBtn = $("update-confirm") as HTMLButtonElement;
+  const laterBtn = $("update-later") as HTMLButtonElement;
+  confirmBtn.disabled = true;
+  laterBtn.disabled = true;
+  $("update-body").textContent = state.labels.updateInstalling;
+  try {
+    await pendingUpdate.downloadAndInstall();
+    await relaunch();
+  } catch (err) {
+    installingUpdate = false;
+    confirmBtn.disabled = false;
+    laterBtn.disabled = false;
+    setUpdateDialogOpen(false);
+    showToast(String(err));
+  }
+}
+
 async function refresh() {
   state = await invoke<LauncherState>("get_launcher_state");
   applyTheme(state.theme);
@@ -244,8 +346,12 @@ function installBeepWorkaround() {
         target instanceof HTMLSelectElement ||
         (target instanceof HTMLElement && target.isContentEditable);
       if (!isEditable) {
-        if (event.key === "Escape" && settingsOpen) {
-          setSettingsOpen(false);
+        if (event.key === "Escape") {
+          if (updateDialogOpen && !installingUpdate) {
+            setUpdateDialogOpen(false);
+          } else if (settingsOpen) {
+            setSettingsOpen(false);
+          }
         }
         // Keep Tab for focus movement; suppress WebView beep for other keys.
         if (event.key !== "Tab") {
@@ -280,6 +386,22 @@ window.addEventListener("DOMContentLoaded", async () => {
 
   $("settings-btn").addEventListener("click", () => setSettingsOpen(!settingsOpen));
   $("settings-backdrop").addEventListener("click", () => setSettingsOpen(false));
+  $("check-update").addEventListener("click", () => {
+    void checkForUpdate("manual");
+  });
+  $("update-later").addEventListener("click", () => {
+    if (!installingUpdate) {
+      setUpdateDialogOpen(false);
+    }
+  });
+  $("update-backdrop").addEventListener("click", () => {
+    if (!installingUpdate) {
+      setUpdateDialogOpen(false);
+    }
+  });
+  $("update-confirm").addEventListener("click", () => {
+    void installPendingUpdate();
+  });
   $("docs-btn").addEventListener("click", async () => {
     try {
       await openUrl(DOCS_URL);
@@ -309,6 +431,7 @@ window.addEventListener("DOMContentLoaded", async () => {
   try {
     await refresh();
     await syncOsTheme();
+    void checkForUpdate("auto");
   } catch (err) {
     showToast(String(err));
   }

--- a/apps/launcher/src/styles.css
+++ b/apps/launcher/src/styles.css
@@ -491,11 +491,86 @@ select {
   border-color: color-mix(in srgb, var(--text) 28%, var(--tile-border));
 }
 
+.primary-btn:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 .settings-status {
   min-height: 1.2em;
   margin: 8px 0 0;
   font-size: 12px;
   color: var(--accent);
+}
+
+.settings-note {
+  min-height: 1.2em;
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+#check-update {
+  margin-top: 10px;
+}
+
+.dialog-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.28);
+  z-index: 45;
+}
+
+.update-dialog {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 50;
+  width: min(420px, calc(100% - 32px));
+  background: var(--panel);
+  border: 1px solid var(--tile-border);
+  border-radius: 16px;
+  box-shadow: var(--shadow);
+  padding: 18px;
+}
+
+.update-dialog h2 {
+  margin: 0 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.update-dialog p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.update-notes {
+  margin: 12px 0 0;
+  padding: 10px 12px;
+  max-height: 160px;
+  overflow: auto;
+  border-radius: 10px;
+  background: var(--panel-2);
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--muted);
+  white-space: pre-wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.dialog-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.dialog-actions .primary-btn {
+  flex: 1;
+  margin-top: 0;
 }
 
 .toast {

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -120,6 +120,30 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::English, "tool.unavailable") => "Not installed",
         (Language::Japanese, "tool.unavailable") => "未インストール",
 
+        // Updater
+        (Language::English, "update.check") => "Check for updates",
+        (Language::Japanese, "update.check") => "更新を確認",
+        (Language::English, "update.checking") => "Checking for updates…",
+        (Language::Japanese, "update.checking") => "更新を確認しています…",
+        (Language::English, "update.available.title") => "Update available",
+        (Language::Japanese, "update.available.title") => "更新があります",
+        (Language::English, "update.available.body") => {
+            "Version {version} is available. The app will restart after installation."
+        }
+        (Language::Japanese, "update.available.body") => {
+            "バージョン {version} が利用できます。インストール後にアプリが再起動します。"
+        }
+        (Language::English, "update.install") => "Update",
+        (Language::Japanese, "update.install") => "更新する",
+        (Language::English, "update.later") => "Later",
+        (Language::Japanese, "update.later") => "後で",
+        (Language::English, "update.none") => "You're up to date.",
+        (Language::Japanese, "update.none") => "最新です。",
+        (Language::English, "update.installing") => "Downloading and installing update…",
+        (Language::Japanese, "update.installing") => "更新をダウンロードしてインストールしています…",
+        (Language::English, "update.failed") => "Could not check for updates.",
+        (Language::Japanese, "update.failed") => "更新の確認に失敗しました。",
+
         // Monitor
         (Language::English, "monitor.sources") => "Sources",
         (Language::Japanese, "monitor.sources") => "ソース",
@@ -489,6 +513,8 @@ mod tests {
             "theme",
             "version",
             "simd",
+            "update.check",
+            "update.available.body",
             "tool.studio_monitor",
             "tool.test_patterns",
             "tool.config_manager",

--- a/crates/suite-core/src/i18n.rs
+++ b/crates/suite-core/src/i18n.rs
@@ -140,7 +140,9 @@ pub fn t(lang: Language, key: &str) -> &'static str {
         (Language::English, "update.none") => "You're up to date.",
         (Language::Japanese, "update.none") => "最新です。",
         (Language::English, "update.installing") => "Downloading and installing update…",
-        (Language::Japanese, "update.installing") => "更新をダウンロードしてインストールしています…",
+        (Language::Japanese, "update.installing") => {
+            "更新をダウンロードしてインストールしています…"
+        }
         (Language::English, "update.failed") => "Could not check for updates.",
         (Language::Japanese, "update.failed") => "更新の確認に失敗しました。",
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "omt-tools",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "packageManager": "bun@1.2.19",
   "scripts": {
     "dev": "bun run --cwd apps/launcher dev",


### PR DESCRIPTION
## Summary
- Check GitHub Releases for a newer suite version when the launcher starts, and from **Check for updates** in Settings (gear).
- If an update is available, show a confirm dialog; accepting downloads, installs, and relaunches the app.
- Bump the suite version to **0.1.1**.

## Test plan
- [ ] Open Settings (gear) and confirm **Check for updates** is labeled in English and Japanese.
- [ ] Manual check with no newer release shows "You're up to date" / "最新です。"
- [ ] Startup check stays silent when already current or when the endpoint is unreachable (e.g. `tauri dev`).
- [ ] With a published newer `latest.json`, both startup and manual check show the dialog with version and notes.
- [ ] Confirming the dialog installs the update and relaunches; Later / Escape / backdrop dismisses it.
- [ ] Packaged installer still uploads updater artifacts (`latest.json`) on release.